### PR TITLE
Use timeout to avoid long blocking builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,10 @@ pipeline
             }
         }
     }
+    options
+    {
+        timeout(time: 2, unit: 'HOURS')
+    }
     stages
     {
         stage('Setup Env')


### PR DESCRIPTION
Please copy the timeout setting to all branches (and adjust if necessary).

Context: I have noticed builds running for 23 hours and just hanging. This unnecessarily binds resources.