### PR TITLE
test(test_proxy_auxiliary.py): make test reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,34 +23,13 @@ Generator command: `npm run change`
 Commit helper: `cz c`
 
 
-## [0.15.0](https://github.com/eclipse/kiso-testing/compare/0.0.0-alpha...0.15.0)
+## [0.15.0](https://github.com/eclipse/kiso-testing/compare/0.15.0...0.15.0)
 
 
 ---
-## 0.0.0-alpha
-> 2022-01-20
+## [0.15.0](https://github.com/eclipse/kiso-testing/compare/0.0.0-alpha...0.15.0)
+> 2022-02-11
 
-#### Commits
-
-- Initial code drop of pykiso [`924e3eb`](https://github.com/eclipse/kiso-testing/commit/924e3eb1e2468f09112bc03c3197785e09f6eb64)
-- Add Jenkinsfile for python-tests [`a2007f8`](https://github.com/eclipse/kiso-testing/commit/a2007f81c4b738f18061ceeb6b6a99d2d6f82f24)
-- Second contribution - one year later [`150eaf9`](https://github.com/eclipse/kiso-testing/commit/150eaf94be18bf563edc4628a56be774500ff028)
-- - clean up the whole kiso-testing (except jenkins file) [`37050f7`](https://github.com/eclipse/kiso-testing/commit/37050f7117deb7926eb95e10098b8474107b90ee)
-- - remove pytest related to python-can [`c74492a`](https://github.com/eclipse/kiso-testing/commit/c74492ad83f22d09d585e14b72f935bff12cc51b)
-- - just erase useless config in pytest test_config_parser [`bbb7b41`](https://github.com/eclipse/kiso-testing/commit/bbb7b41c72591ed3a92c409d298ca3f30e996cd1)
-- add read the doc yaml file [`cc32047`](https://github.com/eclipse/kiso-testing/commit/cc32047946501647693b3532638e6d14561cbc5a)
-- - python version update  from readthedoc config file [`f614576`](https://github.com/eclipse/kiso-testing/commit/f6145762ad21b10f067cd2e728d1fa1964f58e83)
-- add sphinx doc reauirement txt [`9de5361`](https://github.com/eclipse/kiso-testing/commit/9de53612a71f5bb12282ad46b8f95384c031a5f9)
-- add logo to README.md [`63b3a57`](https://github.com/eclipse/kiso-testing/commit/63b3a57680cdd2fdacd1d1d54de4c33855d94a87)
-- Add auxiliary and connector implementation tutorials [`a7eb94a`](https://github.com/eclipse/kiso-testing/commit/a7eb94acd1bc058e32d9793be86305fdf424374d)
-- Update CCPcanCan tests [`6c8b1c9`](https://github.com/eclipse/kiso-testing/commit/6c8b1c95e97ffcaccefaa766921d57f59c2fbb60)
-- prepare twine upload with jenkins [`a6fc89a`](https://github.com/eclipse/kiso-testing/commit/a6fc89a6b358fd742a1daa787aa10b9f2db4876d)
-- Finish implementation examples [`fe9fc77`](https://github.com/eclipse/kiso-testing/commit/fe9fc772c2b214cbf780f0c7ae07172329515d39)
-- Add library to API ref and finish cookbooks [`4a0c643`](https://github.com/eclipse/kiso-testing/commit/4a0c64306d52eb1bc8dd2b5bd2e33410876c315c)
-- Add preface for auxiliary implementation tutorial [`5ff4350`](https://github.com/eclipse/kiso-testing/commit/5ff43502d643d16255867f27e0f964c095f426db)
-- Split auxiliary execution paragraph [`47d4a93`](https://github.com/eclipse/kiso-testing/commit/47d4a93815af7369f229c70f4de41e41648af1d5)
-- Rework auxiliary tutorial [`2dbb7fc`](https://github.com/eclipse/kiso-testing/commit/2dbb7fc69a280982ac0e1816fb79c5427346c79e)
-- add upload stage to pypi [`cefdc33`](https://github.com/eclipse/kiso-testing/commit/cefdc3352ef864a05d6be716226fae60e6b901dd)
 
 ---
 

--- a/tests/test_proxy_auxiliary.py
+++ b/tests/test_proxy_auxiliary.py
@@ -8,18 +8,14 @@
 ##########################################################################
 
 import logging
-import multiprocessing
+import queue
 import sys
 import threading
-import time
-import unittest.mock as mock
 
 import pytest
 
-import pykiso
 from pykiso.connector import CChannel
 from pykiso.lib.auxiliaries.proxy_auxiliary import (
-    AuxiliaryInterface,
     ConfigRegistry,
     ProxyAuxiliary,
     log,
@@ -34,8 +30,8 @@ def mock_auxiliaries(mocker):
     class MockProxyCChannel(CChannel):
         def __init__(self, name=None, *args, **kwargs):
             self.name = name
-            self.queue_in = multiprocessing.Queue()
-            self.queue_out = multiprocessing.Queue()
+            self.queue_in = queue.Queue()
+            self.queue_out = queue.Queue()
             super(MockProxyCChannel, self).__init__(*args, **kwargs)
 
         _cc_open = mocker.stub(name="_cc_open")


### PR DESCRIPTION
multiprocessing Queues are note reliable so switch to queue.queue instead inside unittest.
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue.empty 