### PR TITLE
add the possibility to set default values to ENV variables in the yaml config files

### DIFF
--- a/docs/getting_started/config_file.rst
+++ b/docs/getting_started/config_file.rst
@@ -155,8 +155,8 @@ In the following example, an environment variable called `TEST_SUITE_1` contains
     :language: yaml
     :lines: 22-25
 
-It is also possible to set default value in case the environment variable in not found, the following format should be respected: `ENV{my-env-var=my_default_value}`.
-In the following example, an environment variable called `TEST_SUITE_2` contains the path to the test suite 2 directory and if it is not set the default value ../examples/test_suite_2 will be taken.
+It is also possible to set a default value in case the environment variable is not found. The following format should be used: `ENV{my-env-var=my_default_value}`.
+In the following example, an environment variable called `TEST_SUITE_2` would contain the path to the test_suite_2 directory. If the variable is not set, the default value will be taken instead.
 
 .. literalinclude:: ../../examples/dummy_env_var.yaml
     :language: yaml

--- a/docs/getting_started/config_file.rst
+++ b/docs/getting_started/config_file.rst
@@ -155,6 +155,12 @@ In the following example, an environment variable called `TEST_SUITE_1` contains
     :language: yaml
     :lines: 22-25
 
+It is also possible to set default value in case the environment variable in not found, the following format should be respected: `ENV{my-env-var=my_default_value}`.
+In the following example, an environment variable called `TEST_SUITE_2` contains the path to the test suite 2 directory and if it is not set the default value ../examples/test_suite_2 will be taken.
+
+.. literalinclude:: ../../examples/dummy_env_var.yaml
+    :language: yaml
+    :lines: 14
 
 Specify files and folders
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/dummy_env_var.yaml
+++ b/examples/dummy_env_var.yaml
@@ -23,6 +23,6 @@ test_suite_list:
 - suite_dir: ENV{TEST_SUITE_1}
   test_filter_pattern: '*.py'
   test_suite_id: 1
-- suite_dir: ENV{TEST_SUITE_2=/usr/src/python-lbach/kiso-testing/kiso-testing/examples/test_suite_2}
+- suite_dir: ENV{TEST_SUITE_2=./test_suite_2}
   test_filter_pattern: '*.py'
   test_suite_id: 2

--- a/examples/dummy_env_var.yaml
+++ b/examples/dummy_env_var.yaml
@@ -23,6 +23,6 @@ test_suite_list:
 - suite_dir: ENV{TEST_SUITE_1}
   test_filter_pattern: '*.py'
   test_suite_id: 1
-- suite_dir: ENV{TEST_SUITE_2}
+- suite_dir: ENV{TEST_SUITE_2=/usr/src/python-lbach/kiso-testing/kiso-testing/examples/test_suite_2}
   test_filter_pattern: '*.py'
   test_suite_id: 2

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -189,8 +189,8 @@ def parse_config(fname: PathType) -> typing.Dict:
                 env = match_env_with_val
             else:
                 raise ValueError(
-                        f"Environment variable {match_single_env} not found and no default value specified"
-                )   
+                    f"Environment variable {match_single_env} not found and no default value specified"
+                )
             is_numeric = re.fullmatch(r"\d+", env)
             is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
             is_bool = env.lower() in ["true", "false"]

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -29,7 +29,6 @@ import typing
 from distutils.version import LooseVersion
 from pathlib import Path
 
-import elementpath
 import pkg_resources
 import yaml
 

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -182,16 +182,15 @@ def parse_config(fname: PathType) -> typing.Dict:
             # Parse detected environment variable
             match_single_env = str(match[0][0])
             match_env_with_val = str(match[0][2])
-            try:
+
+            if match_single_env in os.environ:
                 env = os.environ[match_single_env]
-            except KeyError:
-                # Environment variable not found, use the default value if one have been set
-                if match_env_with_val != "":
-                    env = match_env_with_val
-                else:
-                    raise ValueError(
+            elif match_env_with_val:
+                env = match_env_with_val
+            else:
+                raise ValueError(
                         f"Environment variable {match_single_env} not found and no default value specified"
-                    )
+                )   
             is_numeric = re.fullmatch(r"\d+", env)
             is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
             is_bool = env.lower() in ["true", "false"]

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -28,8 +28,8 @@ import sys
 import typing
 from distutils.version import LooseVersion
 from pathlib import Path
-import elementpath
 
+import elementpath
 import pkg_resources
 import yaml
 
@@ -163,9 +163,9 @@ def parse_config(fname: PathType) -> typing.Dict:
         return thing
 
     def _parse_env_var(config_element: str) -> str:
-        """Search for an environment variable pattern in the yaml file and 
-        (1) try to replace it with the value of an environment variable of the same name 
-        (2) Assign the default value if the environment variable was not found 
+        """Search for an environment variable pattern in the yaml file and
+        (1) try to replace it with the value of an environment variable of the same name
+        (2) Assign the default value if the environment variable was not found
         (3) raise an error if 1. and 2. failed
 
         Additionally, cast the value if it matches an integer.
@@ -174,22 +174,24 @@ def parse_config(fname: PathType) -> typing.Dict:
 
         :return: config sub-dict value with replaced environment variable if needed
 
-        :raise: ValueError if the environment variable not found and no default value specified 
+        :raise: ValueError if the environment variable not found and no default value specified
         """
         # Check for regular expression "ENV{word=.}"
         match = re.compile(r"ENV{(\w+)(=(.+))?}").findall(str(config_element))
         if match:
             # Parse detected environment variable
             match_single_env = str(match[0][0])
-            match_env_with_val  = str(match[0][2])
+            match_env_with_val = str(match[0][2])
             try:
                 env = os.environ[match_single_env]
             except KeyError:
                 # Environment variable not found, use the default value if one have been set
-                if match_env_with_val != '':
+                if match_env_with_val != "":
                     env = match_env_with_val
                 else:
-                    raise ValueError(f"Environment variable {match_single_env} not found and no default value specified")
+                    raise ValueError(
+                        f"Environment variable {match_single_env} not found and no default value specified"
+                    )
             is_numeric = re.fullmatch(r"\d+", env)
             is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
             is_bool = env.lower() in ["true", "false"]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -229,6 +229,8 @@ connectors:
       some_integer: 'ENV{int_env_var}'
       some_integer_as_hex:  "ENV{int_env_var_as_hex}"
       some_path: 'ENV{path_env_var}'
+      some_path_default_value: 'ENV{path_env_var_set=/examples/path}'
+      some_path_env_variable_not_set: 'ENV{path_env_var_not_set=/examples/path2}'
     type: pykiso.lib.connectors.cc_example::CCExample
     """
     return cfg
@@ -319,6 +321,7 @@ def test_parse_config_env_var(tmp_cfg_env_var, mocker, tmp_path):
             "int_env_var": "1234567890",
             "int_env_var_as_hex": "0x0123456789aBcDef",
             "path_env_var": f"{tmp_path}",
+            "path_env_var_set": f"{tmp_path}",
         },
     )
     cfg = parse_config(tmp_cfg_env_var)
@@ -330,6 +333,13 @@ def test_parse_config_env_var(tmp_cfg_env_var, mocker, tmp_path):
         == 0x0123456789ABCDEF
     )
     assert cfg["connectors"]["chan1"]["config"]["some_path"] == str(tmp_path)
+    assert cfg["connectors"]["chan1"]["config"]["some_path_default_value"] == str(
+        tmp_path
+    )
+    assert (
+        cfg["connectors"]["chan1"]["config"]["some_path_env_variable_not_set"]
+        == "/examples/path2"
+    )
 
 
 def test_parse_config_folder_name_eq_entity_name(tmp_cfg_mod, mocker, caplog):

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -231,6 +231,7 @@ connectors:
       some_path: 'ENV{path_env_var}'
       some_path_default_value: 'ENV{path_env_var_set=/examples/path}'
       some_path_env_variable_not_set: 'ENV{path_env_var_not_set=/examples/path2}'
+      some_path_env_error: 'ENV{path_env_var_not_set}'
     type: pykiso.lib.connectors.cc_example::CCExample
     """
     return cfg
@@ -324,22 +325,26 @@ def test_parse_config_env_var(tmp_cfg_env_var, mocker, tmp_path):
             "path_env_var_set": f"{tmp_path}",
         },
     )
-    cfg = parse_config(tmp_cfg_env_var)
-    assert cfg["connectors"]["chan1"]["config"]["some_bool"] == True
-    assert cfg["connectors"]["chan1"]["config"]["some_string"] == "this is a string"
-    assert cfg["connectors"]["chan1"]["config"]["some_integer"] == 1234567890
-    assert (
-        cfg["connectors"]["chan1"]["config"]["some_integer_as_hex"]
-        == 0x0123456789ABCDEF
-    )
-    assert cfg["connectors"]["chan1"]["config"]["some_path"] == str(tmp_path)
-    assert cfg["connectors"]["chan1"]["config"]["some_path_default_value"] == str(
-        tmp_path
-    )
-    assert (
-        cfg["connectors"]["chan1"]["config"]["some_path_env_variable_not_set"]
-        == "/examples/path2"
-    )
+
+    # some_path_env_error should raise a ValueError
+    with pytest.raises(ValueError):
+        cfg = parse_config(tmp_cfg_env_var)
+
+        assert cfg["connectors"]["chan1"]["config"]["some_bool"] == True
+        assert cfg["connectors"]["chan1"]["config"]["some_string"] == "this is a string"
+        assert cfg["connectors"]["chan1"]["config"]["some_integer"] == 1234567890
+        assert (
+            cfg["connectors"]["chan1"]["config"]["some_integer_as_hex"]
+            == 0x0123456789ABCDEF
+        )
+        assert cfg["connectors"]["chan1"]["config"]["some_path"] == str(tmp_path)
+        assert cfg["connectors"]["chan1"]["config"]["some_path_default_value"] == str(
+            tmp_path
+        )
+        assert (
+            cfg["connectors"]["chan1"]["config"]["some_path_env_variable_not_set"]
+            == "/examples/path2"
+        )
 
 
 def test_parse_config_folder_name_eq_entity_name(tmp_cfg_mod, mocker, caplog):


### PR DESCRIPTION
Linked to: https://github.com/eclipse/kiso-testing/issues/21

Allow to set default values for env variables in case they are not found with the following syntax:
ENV{ENABLE_KEY_EXCHANGE=True}