### PR TITLE
Feature/restore yaml loader in config parser

### DIFF
--- a/docs/getting_started/config_file.rst
+++ b/docs/getting_started/config_file.rst
@@ -119,7 +119,9 @@ Real-World Configuration File
 Activation of specific loggers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, every logger that does not belong to the `pykiso` package or that is not an `auxiliary` logger will see its level set to WARNING even if you have in the command line `pykiso --log-level DEBUG`.
+By default, every logger that does not belong to the `pykiso` package or that is not an `auxiliary`
+logger will see its level set to WARNING even if you have in the command line `pykiso --log-level DEBUG`.
+
 This aims to reduce redundant logs from additional modules during the test execution.
 For keeping specific loggers to the set log-level, it is possible to set the `activate_log` parameter in the `auxiliary` config.
 The following example activates the `jlink` logger from the `pylink` package, imported in `cc_rtt_segger.py`:
@@ -148,15 +150,19 @@ Based on this example, by specifying `my_pkg`, all child loggers will also be se
 Ability to use environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to replace any value by an environment variable in the YAML files. When using environment variables, the following format should be respected: `ENV{my-env-var}`.
+It is possible to replace any value by an environment variable in the YAML files.
+When using environment variables, the following format should be respected: `ENV{my-env-var}`.
 In the following example, an environment variable called `TEST_SUITE_1` contains the path to the test suite 1 directory.
 
 .. literalinclude:: ../../examples/dummy_env_var.yaml
     :language: yaml
     :lines: 22-25
 
-It is also possible to set a default value in case the environment variable is not found. The following format should be used: `ENV{my-env-var=my_default_value}`.
-In the following example, an environment variable called `TEST_SUITE_2` would contain the path to the test_suite_2 directory. If the variable is not set, the default value will be taken instead.
+It is also possible to set a default value in case the environment variable is not found.
+The following format should be used: `ENV{my-env-var=my_default_value}`.
+
+In the following example, an environment variable called `TEST_SUITE_2` would contain the path to
+the test_suite_2 directory. If the variable is not set, the default value will be taken instead.
 
 .. literalinclude:: ../../examples/dummy_env_var.yaml
     :language: yaml
@@ -166,16 +172,37 @@ Specify files and folders
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To specify files and folders you can use absolute or relative paths.
-Relative paths are always given relative to the location of the yaml file.
+Relative paths are always given **relative to the location of the yaml file**.
 
-Relative path or file locations must always start with "./"
+According to the YAML specification, values enclosed in single quotes are enforced as strings,
+and **will not be parsed**.
 
 .. code:: yaml
 
     example_config:
-        rel_script_path: './script_folder/my_awesome_script.py'
-        abs_script_path_win: 'C:/script_folder/my_awesome_script.py'
-        abs_script_path_unix: '/home/usr/script_folder/my_awesome_script.py'
+        # this relative path will not be made absolute
+        rel_script_path_unresolved: './script_folder/my_awesome_script.py'
+        # this one will
+        rel_script_path: ./script_folder/my_awesome_script.py
+        abs_script_path_win: C:/script_folder/my_awesome_script.py
+        abs_script_path_unix: /home/usr/script_folder/my_awesome_script.py
+
+.. warning::
+  Relative path or file locations must always start with `./`.
+  If not, it will still be resolved but unexpected behaviour can result from it.
+
+Include sub-YAMLs
+~~~~~~~~~~~~~~~~~
+
+Frequently used configuration parts can be stored in a separate YAML file.
+To include this configuration file in the main one, the path to the sub-configuration file has to
+be provided, preceded with the `!include` tag.
+
+Relative paths in the sub-YAML file are then resolved **relative to the sub-YAML's location**.
+
+.. literalinclude:: ../../examples/templates/config_features.yaml
+    :language: yaml
+    :lines: 28-37
 
 Make a proxy auxiliary trace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/templates/config_features.yaml
+++ b/examples/templates/config_features.yaml
@@ -60,6 +60,6 @@ test_suite_list:
 #      displayed
 #_______________________________________________________________________
 requirements:
-  - pykiso : '>=0.10.1'
-  - robotframework : 3.2.2
+  - pykiso: '>=0.10.1, <1.0.0'
+  - robotframework: 3.2.2
   - pyyaml: any

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,8 @@
 # -*- encoding: utf-8 -*-
 
 import io
-import logging
-import platform
-import sys
 from glob import glob
 from os.path import basename, dirname, join, splitext
-from pathlib import Path
 
 from setuptools import find_packages, setup
 

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -25,14 +25,172 @@ import operator
 import os
 import re
 import sys
+from collections import ChainMap
 from distutils.version import LooseVersion
 from pathlib import Path
-from typing import Callable, Dict, List, TextIO, Union
+from typing import Callable, Dict, List, Optional, TextIO, Union
 
 import pkg_resources
 import yaml
 
 from pykiso.types import PathType
+
+
+class YamlLoader(yaml.SafeLoader):
+    """Extension of default yaml.SafeLoader that integrates
+    custom !include tag management and performs config parsing
+    at load time.
+    """
+
+    type_pattern = re.compile(r".*:.*")
+    env_var_pattern = re.compile(r"ENV{(\w+)(=(.+))?}")
+    rel_path_pattern = re.compile(r'[^\n"?:*<>|]')
+
+    def __init__(self, file_path: Union[TextIO, str]):
+        """Initialize attributes.
+
+        For usage with yaml.load, the passed stream must be an actual
+        stream, not its content.
+
+        :param stream: the stream to read or the stream's content.
+        :param file: full path to the YAML file to load.
+        """
+        yaml_file = Path(file_path).resolve()
+        self._base_dir = yaml_file.parent
+        super().__init__(yaml_file.read_text())
+
+    @staticmethod
+    def add_implicit_constructor(
+        tag: str, pattern: re.Pattern, constructor: Callable
+    ) -> None:
+        """Combination of add_implicit_resolver and add_constructor.
+
+        :param tag: explicit tag that can be specified in the YAML file
+        :param pattern: pattern to match to implicitly set the tag
+        :param constructor: function to call when the tag is set
+        """
+        YamlLoader.add_implicit_resolver(tag, pattern, first=None)
+        YamlLoader.add_constructor(tag, constructor)
+
+    @staticmethod
+    def is_key(node: yaml.nodes.ScalarNode) -> bool:
+        """Detect if the provided ScalarNode is a key or a value.
+
+        :param node: ScalarNode instance in use.
+
+        :return: True if the node is a key otherwise False.
+        """
+        if node.end_mark.buffer is None:
+            # undetermined, buffer does not exist when file_path parameter is a stream
+            return True
+        return node.end_mark.buffer[node.end_mark.pointer] == ":"
+
+    def include(self, node: yaml.nodes.ScalarNode) -> dict:
+        """Return the content of a yaml file identified by !include tag.
+
+        :param node: ScalarNode currently in use
+
+        :return: included yaml file's content
+        """
+        nested_yaml = (self._base_dir / Path(node.value)).resolve()
+        nested_cfg = yaml.load(nested_yaml, Loader=YamlLoader)
+        return nested_cfg
+
+    def resolve_path(self, node: yaml.nodes.ScalarNode) -> str:
+        """Resolve a path relative to the config file's location.
+
+        :param node: ScalarNode currently in use
+
+        :return: the resolved config path if needed
+        """
+        if YamlLoader.is_key(node):
+            return str(node.value)
+
+        value = node.value
+        config_path_unresolved = Path(value)
+        if not config_path_unresolved.is_absolute():
+            config_path = (self._base_dir / config_path_unresolved).resolve()
+            if config_path.exists():
+                value = config_path
+                logging.debug(
+                    f"Resolved relative path {config_path_unresolved} to {value}"
+                )
+        return str(value)
+
+    def fix_types_loc(self, node: yaml.nodes.ScalarNode) -> str:
+        """Parse the type field in the config file and resolves it if necessary.
+
+        :param node: ScalarNode currently in use
+
+        :return: type value with resolved relative path
+        """
+        thing = node.value
+        loc, _class = thing.rsplit(":", 1)
+        if not loc.endswith(".py"):
+            return thing
+        path = Path(loc)
+        if not path.is_absolute():
+            path = (self._base_dir / path).resolve()
+            thing = str(path) + ":" + _class
+            logging.debug(f"Resolved path : {thing}")
+        return thing
+
+    def parse_env_var(self, node: yaml.nodes.ScalarNode) -> Union[str, int]:
+        """Parse an environment variable marked as `ENV{env_name=default}`
+        and cast its value if it matches an integer or a boolean.
+
+        .. note::
+            1. if found, the value is replaced with the value of the
+                environment variable of the same name
+            2. if no environment variable exists with this name, check
+                if a default value is provided
+            3. if yes, return the default value, otherwise raise.
+
+        :param node: ScalarNode currently in use.
+
+        :return: config value with replaced environment variable if
+            needed, otherwise the node's value as a string.
+
+        :raises ValueError: if the environment variable could not be
+            found and no default value was specified.
+        """
+        if YamlLoader.is_key(node):
+            return str(node.value)
+        if node.tag == self.DEFAULT_SCALAR_TAG:
+            logging.warning(
+                "YAML warning: environment variables should not be put in quotes"
+            )
+        match = re.findall(self.env_var_pattern, node.value)
+        # no match means the node is just a string
+        if not match:
+            return str(node.value)
+        # Parse detected environment variable
+        env_name, _, env_default = match[0]
+
+        if env_name in os.environ:
+            env = os.environ[env_name]
+        elif env_default is not None:
+            env = env_default
+        else:
+            raise ValueError(
+                f"Environment variable {env_name} not found and no default value specified"
+            )
+        is_numeric = re.fullmatch(r"\d+", env)
+        is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
+        is_bool = env.lower() in ["true", "false"]
+        if is_numeric is not None:
+            config_element = int(env)
+        elif is_hex is not None:
+            config_element = int(env, base=16)
+        elif is_bool:
+            config_element = env.lower() == "true"
+        else:
+            config_element = env
+        logging.debug(f"Replaced environment variable {env_name} with {config_element}")
+        # handle default env var value when being a relative path
+        node.value = config_element
+        config_element = self.resolve_path(node)
+        return config_element
 
 
 def check_requirements(requirements: List[dict]):
@@ -49,236 +207,77 @@ def check_requirements(requirements: List[dict]):
         "!=": operator.ne,
     }
     requirement_satisfied = True
-    for req in requirements:
-        for package, expected_version in req.items():
-            try:
-                logging.debug(f"Check YAML requirements: {package}")
-                current_version = pkg_resources.get_distribution(package).version
-                logging.debug(f"current_version: {current_version}")
+    requirements = dict(ChainMap(*requirements))
 
-                # check if condition provided
-                pattern = r"([<>=!]{1,2})"
-                match = re.split(pattern, expected_version)
-                if len(match) > 1:
-                    # pattern found eg: match = ['', '>=', '0.1.2']
-                    condition = match[1]
-                    exp_version = match[2].strip()
+    for package, expected_version in requirements.items():
+        try:
+            logging.debug(f"Check YAML requirements: {package}")
+            current_version = pkg_resources.get_distribution(package).version
+            logging.debug(f"current_version: {current_version}")
 
-                    try:
-                        compare_operation = condition_to_operator[condition]
-                        check = compare_operation(
-                            LooseVersion(current_version), LooseVersion(exp_version)
-                        )
-                        if check is False:
-                            # Version not satisfied
-                            logging.error(
-                                f"Requirement issue: found {package} with version '{current_version}' but '{expected_version}' given"
-                            )
-                    except KeyError as e:
-                        # comparator invalid
+            if expected_version == "any":
+                continue
+
+            # check if condition provided
+            pattern = r"([<>=!]{1,2})"
+            match = re.split(pattern, expected_version)
+            if len(match) > 1:
+                # pattern found eg: match = ['', '>=', '0.1.2']
+                condition = match[1]
+                exp_version = match[2].strip()
+
+                try:
+                    compare_operation = condition_to_operator[condition]
+                    check = compare_operation(
+                        LooseVersion(current_version), LooseVersion(exp_version)
+                    )
+                    if check is False:
+                        # Version not satisfied
                         logging.error(
-                            f"Requirement issue: comparator '{e}' not among {list(condition_to_operator.keys())}"
+                            f"Requirement issue: found {package} with version '{current_version}' "
+                            f"but '{expected_version}' given"
                         )
-                        check = False
+                except KeyError as e:
+                    # comparator invalid
+                    logging.error(
+                        f"Requirement issue: comparator '{e}' not among {list(condition_to_operator.keys())}"
+                    )
+                    check = False
 
-                    requirement_satisfied &= check
+                requirement_satisfied &= check
 
-                elif current_version != expected_version and expected_version != "any":
-                    if LooseVersion(current_version) < LooseVersion(expected_version):
-                        # Version not satisfied: current_version < expected_version
-                        requirement_satisfied = False
-                        logging.error(
-                            f"Requirement issue: found {package} with version '{current_version}' instead of '{expected_version}' (minimum)"
-                        )
-
-            except pkg_resources.DistributionNotFound:
-                # package not installed or misspelled
+            elif current_version != expected_version and LooseVersion(
+                current_version
+            ) < LooseVersion(expected_version):
+                # Version not satisfied: current_version < expected_version
                 requirement_satisfied = False
-                logging.error(f"Dependency issue: {package} not found")
+                logging.error(
+                    f"Requirement issue: found {package} with version '{current_version}' "
+                    f"instead of '{expected_version}' (minimum)"
+                )
+
+        except pkg_resources.DistributionNotFound:
+            # package not installed or misspelled
+            requirement_satisfied = False
+            logging.error(f"Dependency issue: {package} not found")
 
     if not requirement_satisfied:
         logging.error("At least one requirement is not satisfied")
         sys.exit(1)
 
 
-def parse_config(fname: PathType) -> Dict:
+def parse_config(file_name: PathType) -> Dict:
     """Parse YAML config file.
 
-    :param fname: path to the config file
+    .. note::
+        The parsing includes:
+
+
+    :param file_name: path to the config file
 
     :return: config dict with resolved paths where needed
     """
-
-    class YamlLoader(yaml.SafeLoader):
-        """Extension of default yaml.SafeLoader that integrates
-        custom !include tag management and performs config parsing
-        at load time.
-        """
-
-        type_pattern = re.compile(r".*:.*")
-        env_var_pattern = re.compile(r"ENV{(\w+)(=(.+))?}")
-        rel_path_pattern = re.compile(r'[^\n"?:*<>|]')
-
-        def __init__(self, stream: TextIO):
-            """Initialize attributes.
-
-            :param stream: current stream in use
-            """
-            self._root = Path(fname).parent
-            super().__init__(stream)
-
-        @staticmethod
-        def add_implicit_constructor(
-            tag: str, pattern: re.Pattern, constructor: Callable
-        ) -> None:
-            """Combination of add_implicit_resolver and add_constructor.
-
-            :param tag: explicit tag that can be specified in the YAML file
-            :param pattern: pattern to match to implicitly set the tag
-            :param constructor: function to call when the tag is set
-            """
-            YamlLoader.add_implicit_resolver(tag, pattern, first=None)
-            YamlLoader.add_constructor(tag, constructor)
-
-        @staticmethod
-        def is_key(node: yaml.nodes.ScalarNode) -> bool:
-            print()
-            print("Value", node.value)
-            print("Tag", node.tag)
-            end_mark: yaml.error.Mark = node.end_mark
-            if end_mark.buffer is None:
-                print("\n    buffer", node.end_mark.buffer)
-                print("\n    column", node.end_mark.column)
-                print("\n    index", node.end_mark.index)
-                print("\n    line", node.end_mark.line)
-                print("\n    name", node.end_mark.name)
-                print("\n    pointer", node.end_mark.pointer)
-                return True
-            print("Test start", node.start_mark.buffer[node.start_mark.pointer])
-            print("Test end", node.end_mark.buffer[node.end_mark.pointer])
-            return node.end_mark.buffer[node.end_mark.pointer] == ":"
-
-
-        def include(self, node: yaml.nodes.ScalarNode) -> dict:
-            """Return the content of a yaml file identified by !include
-            tag.
-
-            :param node: ScalarNode currently in use
-
-            :return: yaml file content
-            """
-            print("*************** INCLUDE")
-            print("\n    buffer", node.end_mark.buffer)
-            print("\n    column", node.end_mark.column)
-            print("\n    index", node.end_mark.index)
-            print("\n    line", node.end_mark.line)
-            print("\n    name", node.end_mark.name)
-            print("\n    pointer", node.end_mark.pointer)
-            filename = (self._root / Path(node.value)).resolve()
-            return yaml.load(filename.read_text(), Loader=YamlLoader)
-
-        def resolve_path(self, node: yaml.nodes.ScalarNode) -> str:
-            """Resolve a path relative to the config file's location.
-
-            :param node: ScalarNode currently in use
-
-            :return: the resolved config path if needed
-            """
-
-            """
-            print("Start mark", node.start_mark)
-            print("End mark")
-            print("\n    buffer", node.end_mark.buffer)
-            print("\n    column", node.end_mark.column)
-            print("\n    index", node.end_mark.index)
-            print("\n    line", node.end_mark.line)
-            print("\n    name", node.end_mark.name)
-            print("\n    pointer", node.end_mark.pointer)
-            """
-
-            if YamlLoader.is_key(node):
-                return str(node.value)
-
-            # print("ID", node.id)
-            # print("Style", node.style)
-            value = node.value
-            config_path_unresolved = Path(value)
-            if not config_path_unresolved.is_absolute():
-                config_path = (self._root / config_path_unresolved).resolve()
-                if config_path.exists():
-                    value = config_path
-                    logging.debug(
-                        f"Resolved relative path {config_path_unresolved} to {value}"
-                    )
-            return str(value)
-
-        def fix_types_loc(self, node: yaml.nodes.ScalarNode) -> str:
-            """Parse the type field in the config file and resolves it if necessary.
-
-            :param node: ScalarNode currently in use
-
-            :return: config sub-dict containing the resolved type if needed
-            """
-            thing = node.value
-            loc, _class = thing.rsplit(":", 1)
-            if not loc.endswith(".py"):
-                return thing
-            path = Path(loc)
-            if not path.is_absolute():
-                path = (self._root / path).resolve()
-                thing = str(path) + ":" + _class
-                logging.debug(f"Resolved path : {thing}")
-            return thing
-
-        def parse_env_var(self, node: yaml.nodes.ScalarNode) -> Union[str, int]:
-            """Search for an environment variable pattern in the yaml file and
-            (1) try to replace it with the value of an environment variable of the same name
-            (2) Assign the default value if the environment variable was not found
-            (3) raise an error if 1. and 2. failed
-
-            Additionally, cast the value if it matches an integer.
-
-            :param node: ScalarNode currently in use
-
-            :return: config sub-dict value with replaced environment variable if needed
-
-            :raise: ValueError if the environment variable not found and no default value specified
-            """
-            if node.tag == self.DEFAULT_SCALAR_TAG:
-                logging.warning(
-                    "YAML warning: environment variables should not be put in quotes"
-                )
-            match = re.findall(self.env_var_pattern, node.value)
-            # no match means the node is just a string
-            if not match:
-                return str(node.value)
-            # Parse detected environment variable
-            match_single_env = str(match[0][0])
-            match_env_with_val = str(match[0][2])
-
-            if match_single_env in os.environ:
-                env = os.environ[match_single_env]
-            elif match_env_with_val:
-                env = match_env_with_val
-            else:
-                raise ValueError(
-                    f"Environment variable {match_single_env} not found and no default value specified"
-                )
-            is_numeric = re.fullmatch(r"\d+", env)
-            is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
-            is_bool = env.lower() in ["true", "false"]
-            if is_numeric is not None:
-                config_element = int(env)
-            elif is_hex is not None:
-                config_element = int(env, base=16)
-            elif is_bool:
-                config_element = env.lower() == "true"
-            else:
-                config_element = env
-            logging.debug(
-                f"Replaced environment variable {match_single_env} with {config_element}"
-            )
-
+    # allow loading paths to sub-yamls
     YamlLoader.add_constructor("!include", YamlLoader.include)
     # parse quoted environment variables
     YamlLoader.add_constructor(YamlLoader.DEFAULT_SCALAR_TAG, YamlLoader.parse_env_var)
@@ -286,14 +285,16 @@ def parse_config(fname: PathType) -> Dict:
     YamlLoader.add_implicit_constructor(
         "!env", YamlLoader.env_var_pattern, YamlLoader.parse_env_var
     )
+    # parse auxiliary and connector types
     YamlLoader.add_implicit_constructor(
         "!type", YamlLoader.type_pattern, YamlLoader.fix_types_loc
     )
+    # parse relative paths
     YamlLoader.add_implicit_constructor(
         "!resolve", YamlLoader.rel_path_pattern, YamlLoader.resolve_path
     )
 
-    cfg = yaml.load(f.read_text(), Loader=YamlLoader)
+    cfg = yaml.load(file_name, Loader=YamlLoader)
 
     # Check requirements
     requirements = cfg.get("requirements")

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -52,7 +52,6 @@ class YamlLoader(yaml.SafeLoader):
         For usage with yaml.load, the passed stream must be a path to the
         YAML file or an actual stream, not its read content.
 
-        :param stream: the stream to read or the stream's content.
         :param file: full path to the YAML file to load.
         """
         if isinstance(file, TextIOWrapper):

--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -20,28 +20,34 @@ Configuration File Parser
 
 """
 
-import ast
-import io
 import logging
+import operator
 import os
 import re
 import sys
-import typing
 from distutils.version import LooseVersion
 from pathlib import Path
-from typing import Callable, TextIO, Union
+from typing import Callable, Dict, List, TextIO, Union
 
 import pkg_resources
 import yaml
 
-from .types import PathType
+from pykiso.types import PathType
 
 
-def check_requirements(requirements: list):
+def check_requirements(requirements: List[dict]):
     """Check the environment before running the tests
 
     :param requirements: requirements to be checked
     """
+    condition_to_operator = {
+        "<": operator.lt,
+        "<=": operator.le,
+        ">": operator.gt,
+        ">=": operator.ge,
+        "==": operator.eq,
+        "!=": operator.ne,
+    }
     requirement_satisfied = True
     for req in requirements:
         for package, expected_version in req.items():
@@ -57,31 +63,21 @@ def check_requirements(requirements: list):
                     # pattern found eg: match = ['', '>=', '0.1.2']
                     condition = match[1]
                     exp_version = match[2].strip()
-                    check = (
-                        LooseVersion(current_version) < LooseVersion(exp_version)
-                        if condition == "<"
-                        else LooseVersion(current_version) <= LooseVersion(exp_version)
-                        if condition == "<="
-                        else LooseVersion(current_version) > LooseVersion(exp_version)
-                        if condition == ">"
-                        else LooseVersion(current_version) >= LooseVersion(exp_version)
-                        if condition == ">="
-                        else LooseVersion(current_version) == LooseVersion(exp_version)
-                        if condition == "=="
-                        else LooseVersion(current_version) != LooseVersion(exp_version)
-                        if condition == "!="
-                        else None
-                    )
 
-                    if check is False:
-                        # Version not satisfied
-                        logging.error(
-                            f"Requirement issue: found {package} with version '{current_version}' but '{expected_version}' given"
+                    try:
+                        compare_operation = condition_to_operator[condition]
+                        check = compare_operation(
+                            LooseVersion(current_version), LooseVersion(exp_version)
                         )
-                    elif check is None:
+                        if check is False:
+                            # Version not satisfied
+                            logging.error(
+                                f"Requirement issue: found {package} with version '{current_version}' but '{expected_version}' given"
+                            )
+                    except KeyError as e:
                         # comparator invalid
                         logging.error(
-                            f"Requirement issue: comparator '{condition}' not among [<, <=, >, >=, ==, !=]"
+                            f"Requirement issue: comparator '{e}' not among {list(condition_to_operator.keys())}"
                         )
                         check = False
 
@@ -105,178 +101,7 @@ def check_requirements(requirements: list):
         sys.exit(1)
 
 
-def parse_config(fname: PathType) -> typing.Dict:
-    """Parse YAML config file.
-
-    :param fname: path to the config file
-
-    :return: config dict with resolved paths where needed
-    """
-
-    class YamlLoader(yaml.SafeLoader):
-        """Extension of default yaml.SafeLoader who integrates
-        custom !include tag management.
-        """
-
-        def __init__(self, stream: io.TextIOWrapper):
-            """Initialize attributes.
-
-            :param stream: current stream in use
-            """
-            self._root = Path(fname).resolve().parent
-            super().__init__(stream)
-
-        def include(self, node: yaml.nodes.ScalarNode) -> dict:
-            """Return the content of an yaml file identify by !include
-            tag.
-
-            :param node: ScalarNode currently in use
-
-            :return: yaml file content
-            """
-            filename = (self._root / Path(node.value)).resolve()
-            with open(filename, "r") as f:
-                return yaml.load(f, Loader=YamlLoader)
-
-    YamlLoader.add_constructor("!include", YamlLoader.include)
-
-    with open(fname) as f:
-        cfg = yaml.load(f.read(), Loader=YamlLoader)
-
-    # fix suite-dirs
-    base_dir = Path(fname).resolve().parent
-
-    def _fix_types_loc(thing: dict) -> dict:
-        """Parse the type field in the config file and resolves it if necessary.
-
-        :param thing: config sub-dict containing the type
-
-        :return: config sub-dict containing the resolved type if needed
-        """
-        loc, _class = thing["type"].rsplit(":", 1)
-        if not loc.endswith(".py"):
-            return thing
-        path = Path(loc)
-        if not path.is_absolute():
-            path = (base_dir / path).resolve()
-            thing["type"] = str(path) + ":" + _class
-            logging.debug(f'Resolved path : {thing["type"]}')
-        return thing
-
-    def _parse_env_var(config_element: str) -> str:
-        """Search for an environment variable pattern in the yaml file and
-        (1) try to replace it with the value of an environment variable of the same name
-        (2) Assign the default value if the environment variable was not found
-        (3) raise an error if 1. and 2. failed
-
-        Additionally, cast the value if it matches an integer.
-
-        :param config_element: config sub-dict value
-
-        :return: config sub-dict value with replaced environment variable if needed
-
-        :raise: ValueError if the environment variable not found and no default value specified
-        """
-        # Check for regular expression "ENV{word=.}"
-        match = re.compile(r"ENV{(\w+)(=(.+))?}").findall(str(config_element))
-        if match:
-            # Parse detected environment variable
-            match_single_env = str(match[0][0])
-            match_env_with_val = str(match[0][2])
-
-            if match_single_env in os.environ:
-                env = os.environ[match_single_env]
-            elif match_env_with_val:
-                env = match_env_with_val
-            else:
-                raise ValueError(
-                    f"Environment variable {match_single_env} not found and no default value specified"
-                )
-            is_numeric = re.fullmatch(r"\d+", env)
-            is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
-            is_bool = env.lower() in ["true", "false"]
-            if is_numeric is not None:
-                config_element = int(env)
-            elif is_hex is not None:
-                config_element = int(env, base=16)
-            elif is_bool:
-                config_element = env.lower() == "true"
-            else:
-                config_element = env
-            logging.debug(
-                f"Replaced environment variable {match_single_env} with {config_element}"
-            )
-        return config_element
-
-    def _resolve_path(config_path: str) -> str:
-        """Resolve a path relative to the config file's location.
-
-        :param config_path: a config path
-
-        :return: the resolved config path if needed
-        """
-        config_path_unresolved = Path(config_path)
-        if not config_path_unresolved.is_absolute():
-            config_path = (base_dir / config_path_unresolved).resolve()
-            logging.debug(
-                f"Resolved relative path {config_path_unresolved} to {config_path}"
-            )
-        return str(config_path)
-
-    def _check_path(path: str) -> bool:
-        """Check if the argument is a valid path.
-
-        :param path: any string in the config file's values
-
-        :return: a boolean indicating if the string is a valid path
-        """
-        is_valid = False
-        if "./" in path.replace(".\\", "./"):
-            invalid_characters = (":", "*", "?", "<", ">", "|")
-            is_valid = (
-                False
-                if (any(c in invalid_characters for c in path))
-                else (Path(path).exists() or (base_dir / Path(path)).exists())
-            )
-        return is_valid
-
-    def _resolve_config_paths(config: dict) -> dict:
-        """Iterate over the config dict and resolve all of the config file paths.
-
-        :param config: config dict
-
-        :return: config dict with resolved paths
-        """
-        for key in config.keys():
-            if isinstance(config.get(key), dict):
-                _resolve_config_paths(config.get(key))
-            elif isinstance(config.get(key), str):
-                config[key] = _parse_env_var(config[key])
-                config[key] = (
-                    _resolve_path(config[key])
-                    if isinstance(config[key], str) and _check_path(config[key])
-                    else config[key]
-                )
-            elif isinstance(config.get(key), list) and key == "test_suite_list":
-                for test_suite in config[key]:
-                    test_suite["suite_dir"] = _resolve_path(
-                        _parse_env_var(test_suite["suite_dir"])
-                    )
-        return config
-
-    cfg["connectors"] = {n: _fix_types_loc(s) for n, s in cfg["connectors"].items()}
-    cfg["auxiliaries"] = {n: _fix_types_loc(s) for n, s in cfg["auxiliaries"].items()}
-    cfg = _resolve_config_paths(cfg)
-
-    # Check requirements
-    requirements = cfg.get("requirements")
-    if requirements:
-        check_requirements(requirements)
-
-    return cfg
-
-
-def _parse_config(fname: PathType) -> typing.Dict:
+def parse_config(fname: PathType) -> Dict:
     """Parse YAML config file.
 
     :param fname: path to the config file
@@ -291,7 +116,7 @@ def _parse_config(fname: PathType) -> typing.Dict:
         """
 
         type_pattern = re.compile(r".*:.*")
-        env_var_pattern = re.compile(r"ENV{(\w+)}")
+        env_var_pattern = re.compile(r"ENV{(\w+)(=(.+))?}")
         rel_path_pattern = re.compile(r'[^\n"?:*<>|]')
 
         def __init__(self, stream: TextIO):
@@ -315,17 +140,42 @@ def _parse_config(fname: PathType) -> typing.Dict:
             YamlLoader.add_implicit_resolver(tag, pattern, first=None)
             YamlLoader.add_constructor(tag, constructor)
 
+        @staticmethod
+        def is_key(node: yaml.nodes.ScalarNode) -> bool:
+            print()
+            print("Value", node.value)
+            print("Tag", node.tag)
+            end_mark: yaml.error.Mark = node.end_mark
+            if end_mark.buffer is None:
+                print("\n    buffer", node.end_mark.buffer)
+                print("\n    column", node.end_mark.column)
+                print("\n    index", node.end_mark.index)
+                print("\n    line", node.end_mark.line)
+                print("\n    name", node.end_mark.name)
+                print("\n    pointer", node.end_mark.pointer)
+                return True
+            print("Test start", node.start_mark.buffer[node.start_mark.pointer])
+            print("Test end", node.end_mark.buffer[node.end_mark.pointer])
+            return node.end_mark.buffer[node.end_mark.pointer] == ":"
+
+
         def include(self, node: yaml.nodes.ScalarNode) -> dict:
-            """Return the content of an yaml file identify by !include
+            """Return the content of a yaml file identified by !include
             tag.
 
             :param node: ScalarNode currently in use
 
             :return: yaml file content
             """
-            filename = self._root / Path(node.value).resolve()
-            with open(filename, "r") as f:
-                return yaml.load(f, Loader=YamlLoader)
+            print("*************** INCLUDE")
+            print("\n    buffer", node.end_mark.buffer)
+            print("\n    column", node.end_mark.column)
+            print("\n    index", node.end_mark.index)
+            print("\n    line", node.end_mark.line)
+            print("\n    name", node.end_mark.name)
+            print("\n    pointer", node.end_mark.pointer)
+            filename = (self._root / Path(node.value)).resolve()
+            return yaml.load(filename.read_text(), Loader=YamlLoader)
 
         def resolve_path(self, node: yaml.nodes.ScalarNode) -> str:
             """Resolve a path relative to the config file's location.
@@ -334,6 +184,23 @@ def _parse_config(fname: PathType) -> typing.Dict:
 
             :return: the resolved config path if needed
             """
+
+            """
+            print("Start mark", node.start_mark)
+            print("End mark")
+            print("\n    buffer", node.end_mark.buffer)
+            print("\n    column", node.end_mark.column)
+            print("\n    index", node.end_mark.index)
+            print("\n    line", node.end_mark.line)
+            print("\n    name", node.end_mark.name)
+            print("\n    pointer", node.end_mark.pointer)
+            """
+
+            if YamlLoader.is_key(node):
+                return str(node.value)
+
+            # print("ID", node.id)
+            # print("Style", node.style)
             value = node.value
             config_path_unresolved = Path(value)
             if not config_path_unresolved.is_absolute():
@@ -364,29 +231,53 @@ def _parse_config(fname: PathType) -> typing.Dict:
             return thing
 
         def parse_env_var(self, node: yaml.nodes.ScalarNode) -> Union[str, int]:
-            """Search for an environment variable and replace it with the associated value.
+            """Search for an environment variable pattern in the yaml file and
+            (1) try to replace it with the value of an environment variable of the same name
+            (2) Assign the default value if the environment variable was not found
+            (3) raise an error if 1. and 2. failed
 
-            Additionally, cast the value if it matches a python type supported by ast.literal_eval().
+            Additionally, cast the value if it matches an integer.
 
             :param node: ScalarNode currently in use
 
             :return: config sub-dict value with replaced environment variable if needed
+
+            :raise: ValueError if the environment variable not found and no default value specified
             """
-            match = re.search(self.env_var_pattern, node.value)
+            if node.tag == self.DEFAULT_SCALAR_TAG:
+                logging.warning(
+                    "YAML warning: environment variables should not be put in quotes"
+                )
+            match = re.findall(self.env_var_pattern, node.value)
             # no match means the node is just a string
-            if match is None:
+            if not match:
                 return str(node.value)
-            env_name = match.group(1)
-            env = os.environ[env_name]
-            # cast the env var's value
-            try:
-                config_element = ast.literal_eval(env)
-            except Exception:
+            # Parse detected environment variable
+            match_single_env = str(match[0][0])
+            match_env_with_val = str(match[0][2])
+
+            if match_single_env in os.environ:
+                env = os.environ[match_single_env]
+            elif match_env_with_val:
+                env = match_env_with_val
+            else:
+                raise ValueError(
+                    f"Environment variable {match_single_env} not found and no default value specified"
+                )
+            is_numeric = re.fullmatch(r"\d+", env)
+            is_hex = re.fullmatch(r"0x[0-9a-fA-F]+", env)
+            is_bool = env.lower() in ["true", "false"]
+            if is_numeric is not None:
+                config_element = int(env)
+            elif is_hex is not None:
+                config_element = int(env, base=16)
+            elif is_bool:
+                config_element = env.lower() == "true"
+            else:
                 config_element = env
             logging.debug(
-                f"Replaced environment variable {env_name} with {config_element}"
+                f"Replaced environment variable {match_single_env} with {config_element}"
             )
-            return config_element
 
     YamlLoader.add_constructor("!include", YamlLoader.include)
     # parse quoted environment variables
@@ -402,7 +293,20 @@ def _parse_config(fname: PathType) -> typing.Dict:
         "!resolve", YamlLoader.rel_path_pattern, YamlLoader.resolve_path
     )
 
-    with open(fname) as f:
-        cfg = yaml.load(f.read(), Loader=YamlLoader)
+    cfg = yaml.load(f.read_text(), Loader=YamlLoader)
+
+    # Check requirements
+    requirements = cfg.get("requirements")
+    if requirements:
+        check_requirements(requirements)
 
     return cfg
+
+
+if __name__ == "__main__":
+    import json
+
+    os.environ["TEST_SUITE_1"] = "test_suite_1"
+    f = Path(__file__).resolve().parent / "nested_yaml/test.yaml"
+
+    print(json.dumps(parse_config(f), indent=2))

--- a/src/pykiso/test_coordinator/test_suite.py
+++ b/src/pykiso/test_coordinator/test_suite.py
@@ -218,7 +218,7 @@ class BasicTestSuite(unittest.TestSuite):
     ):
         """Initialize our custom unittest-test-suite.
 
-        .. note:
+        .. note::
             1. Will Load from the given path the integration test modules under test
             2. Sort the given test case list by test suite/case id
             3. Place Test suite setup and teardown respectively at top and bottom of test case list

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -264,10 +264,6 @@ def test_parse_config(tmp_cfg, tmp_path, mocker, caplog):
     with caplog.at_level(logging.DEBUG):
         cfg = parse_config(tmp_cfg)
 
-    import json
-
-    print(json.dumps(cfg, indent=2))
-
     # Test _fix_types_loc
     assert "Resolved path :" in caplog.text
     assert (
@@ -331,10 +327,6 @@ def test_parse_config_env_var(tmp_cfg_env_var, mocker, tmp_path):
     # some_path_env_error should raise a ValueError
     with pytest.raises(ValueError):
         cfg = parse_config(tmp_cfg_env_var)
-
-        import json
-
-        print(json.dumps(cfg, indent=2))
 
         assert cfg["connectors"]["chan1"]["config"]["some_bool"] == True
         assert cfg["connectors"]["chan1"]["config"]["some_string"] == "this is a string"


### PR DESCRIPTION
Highest complexity is now in parse_requirements with a score of 11

Breaking changes:
- relative paths in nested YAMLs are now relative to the nested YAML
- multiple version requirements are now expressed as `- pykiso: >=15.0.0, <16.0.0` instead of `- pykiso: >=15.0.0` `-pykiso: <16.0.0`

As it is impossible to know if a config value corresponding to a valid relative path actually is a path or not, we should enforce single quotes in values that shouldn't be parsed