### PR TITLE
raise an exception when auxiliary failed at instance creation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,6 @@ black = "21.11b1"
 
 [packages]
 pyserial = "*"
-timeout-decorator = "*"
 click = "*"
 pyyaml = "*"
 pykiso = {editable = true,path = "."}

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Options:
   --junit                         enables the generation of a junit report
   --text                          default, test results are only displayed in
                                   the console
+  --failfast                      stop the test run on the first error or
+                                  failure
 ```
 
 Suitable config files are available in the `examples` folder.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ def read(*names, **kwargs):
 
 install_requires = [
     "pyserial",
-    "timeout-decorator",
     "click",
     "pyyaml",
     "pylink-square",

--- a/src/pykiso/auxiliary.py
+++ b/src/pykiso/auxiliary.py
@@ -230,18 +230,23 @@ class AuxiliaryCommon(metaclass=abc.ABCMeta):
         self.stop_event.set()
 
     def resume(self) -> None:
-        """Resume current auxiliary's run."""
+        """Resume current auxiliary's run, by running the
+        create_instance method in the background.
+
+        .. warning:: due to the usage of create_instance if an issue
+            occurred the exception AuxiliaryCreationError is raised.
+        """
         if not self.stop_event.is_set() and not self.is_instance:
             self.create_instance()
         else:
-            log.error(f"Auxiliary '{self}' is already running")
+            log.warning(f"Auxiliary '{self}' is already running")
 
     def suspend(self) -> None:
         """Supend current auxiliary's run."""
         if self.is_instance:
             self.delete_instance()
         else:
-            log.error(f"Auxiliary '{self}' is already stopped")
+            log.warning(f"Auxiliary '{self}' is already stopped")
 
     @abc.abstractmethod
     def create_instance(self) -> bool:

--- a/src/pykiso/auxiliary.py
+++ b/src/pykiso/auxiliary.py
@@ -234,23 +234,23 @@ class AuxiliaryCommon(metaclass=abc.ABCMeta):
         if not self.stop_event.is_set() and not self.is_instance:
             self.create_instance()
         else:
-            log.error("Cannot resume auxiliary, error occurred during creation")
+            log.error(f"Auxiliary '{self}' is already running")
 
     def suspend(self) -> None:
         """Supend current auxiliary's run."""
         if self.is_instance:
             self.delete_instance()
         else:
-            log.error("Cannot suspend auxiliary, error occurred during creation")
+            log.error(f"Auxiliary '{self}' is already stopped")
 
     @abc.abstractmethod
     def create_instance(self) -> bool:
-        """Run function of the auxiliary."""
+        """Handle auxiliary creation."""
         pass
 
     @abc.abstractmethod
     def delete_instance(self) -> bool:
-        """Run function of the auxiliary."""
+        """Handle auxiliary deletion."""
         pass
 
     @abc.abstractmethod

--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -174,7 +174,7 @@ def get_logging_options() -> LogOptions:
     help="allow the user to execute a subset of tests based on branch levels",
 )
 @click.option(
-    "--fail-fast",
+    "--failfast",
     is_flag=True,
     help="stop the test run on the first error or failure",
 )
@@ -189,7 +189,7 @@ def main(
     variant: Optional[tuple] = None,
     branch_level: Optional[tuple] = None,
     pattern: Optional[str] = None,
-    fail_fast: bool = False,
+    failfast: bool = False,
 ):
     """Embedded Integration Test Framework - CLI Entry Point.
 
@@ -203,7 +203,7 @@ def main(
     :param variant: allow the user to execute a subset of tests based on variants
     :param branch_level: allow the user to execute a subset of tests based on branch levels
     :param pattern: overwrite the pattern from the YAML file for easier testdevelopment
-    :param fail_fast: stop the test run on the first error or failure
+    :param failfast: stop the test run on the first error or failure
     """
     # Set the logging
     logger = initialize_logging(log_path, log_level, report_type)
@@ -215,7 +215,7 @@ def main(
     ConfigRegistry.register_aux_con(cfg_dict)
 
     exit_code = test_execution.execute(
-        cfg_dict, report_type, variant, branch_level, pattern, fail_fast
+        cfg_dict, report_type, variant, branch_level, pattern, failfast
     )
     ConfigRegistry.delete_aux_con()
     sys.exit(exit_code)

--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -173,6 +173,11 @@ def get_logging_options() -> LogOptions:
     default=None,
     help="allow the user to execute a subset of tests based on branch levels",
 )
+@click.option(
+    "--fail-fast",
+    is_flag=True,
+    help="stop the test run on the first error or failure",
+)
 @click.argument("pattern", required=False)
 @click.version_option(__version__)
 @Grabber.grab_cli_config
@@ -184,6 +189,7 @@ def main(
     variant: Optional[tuple] = None,
     branch_level: Optional[tuple] = None,
     pattern: Optional[str] = None,
+    fail_fast: bool = False,
 ):
     """Embedded Integration Test Framework - CLI Entry Point.
 
@@ -197,6 +203,7 @@ def main(
     :param variant: allow the user to execute a subset of tests based on variants
     :param branch_level: allow the user to execute a subset of tests based on branch levels
     :param pattern: overwrite the pattern from the YAML file for easier testdevelopment
+    :param fail_fast: stop the test run on the first error or failure
     """
     # Set the logging
     logger = initialize_logging(log_path, log_level, report_type)
@@ -208,7 +215,7 @@ def main(
     ConfigRegistry.register_aux_con(cfg_dict)
 
     exit_code = test_execution.execute(
-        cfg_dict, report_type, variant, branch_level, pattern
+        cfg_dict, report_type, variant, branch_level, pattern, fail_fast
     )
     ConfigRegistry.delete_aux_con()
     sys.exit(exit_code)

--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -1,0 +1,34 @@
+##########################################################################
+# Copyright (c) 2010-2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+##########################################################################
+
+"""
+:module: exceptions
+
+:synopsis: Define all custom exceptions raised by pykiso framework
+
+.. currentmodule:: exceptions
+"""
+
+
+class PykisoError(Exception):
+    """General XCP specific exception used as basis for all others."""
+
+    def __str__(self):
+        return self.message
+
+class AuxiliaryCreationError(PykisoError):
+    """Raised when an auxiliary instance creation failed,"""
+
+    def __init__(self, aux_name: str) -> None:
+        """Initialize attributes.
+
+        :param aux_name: aux alias
+        """
+        self.message = f"Auxiliary {aux_name} failed at instance creation"
+        super().__init__(self.message)

--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -17,13 +17,14 @@
 
 
 class PykisoError(Exception):
-    """General XCP specific exception used as basis for all others."""
+    """Pykiso specific exception used as basis for all others."""
 
     def __str__(self):
         return self.message
 
+
 class AuxiliaryCreationError(PykisoError):
-    """Raised when an auxiliary instance creation failed,"""
+    """Raised when an auxiliary instance creation failed."""
 
     def __init__(self, aux_name: str) -> None:
         """Initialize attributes.

--- a/src/pykiso/interfaces/mp_auxiliary.py
+++ b/src/pykiso/interfaces/mp_auxiliary.py
@@ -45,7 +45,6 @@ class MpAuxiliaryInterface(multiprocessing.Process, AuxiliaryCommon):
         self,
         name: str = None,
         is_proxy_capable: bool = False,
-        is_pausable: bool = False,
         activate_log: List[str] = None,
     ) -> None:
         """Auxiliary initialization.
@@ -53,8 +52,6 @@ class MpAuxiliaryInterface(multiprocessing.Process, AuxiliaryCommon):
         :param name: alias of the auxiliary instance
         :param is_proxy_capable: notify if the current auxiliary could
             be (or not) associated to a proxy-auxiliary.
-        :param is_pausable: notify if the current auxiliary could be
-            (or not) paused
         :param activate_log: loggers to deactivate
         """
         self.name = name
@@ -65,7 +62,6 @@ class MpAuxiliaryInterface(multiprocessing.Process, AuxiliaryCommon):
         self.stop_event = multiprocessing.Event()
         self.wait_event = multiprocessing.Event()
         self.is_proxy_capable = is_proxy_capable
-        self.is_pausable = is_pausable
         self.logger = None
         self.is_instance = False
         # store the logging information
@@ -181,7 +177,7 @@ class MpAuxiliaryInterface(multiprocessing.Process, AuxiliaryCommon):
                 self.logger.warning(f"Aux status: {self.__dict__}")
 
             # Step 2: Check if something was received from the aux instance if instance was created
-            if self.is_instance and not self.is_pausable:
+            if self.is_instance:
                 received_message = self._receive_message(timeout_in_s=0)
                 # If yes, send it via the out queue
                 if received_message is not None:
@@ -191,9 +187,6 @@ class MpAuxiliaryInterface(multiprocessing.Process, AuxiliaryCommon):
             if not self.is_instance:
                 time.sleep(0.050)
 
-            # If auxiliary instance is created and is pausable
-            if self.is_instance and self.is_pausable:
-                self.wait_event.wait()
         # Thread stop command was set
         self.logger.info("{} was stopped".format(self))
         # Delete auxiliary external instance if not done

--- a/src/pykiso/interfaces/mp_auxiliary.py
+++ b/src/pykiso/interfaces/mp_auxiliary.py
@@ -60,7 +60,6 @@ class MpAuxiliaryInterface(multiprocessing.Process, AuxiliaryCommon):
         self.queue_in = multiprocessing.Queue()
         self.queue_out = multiprocessing.Queue()
         self.stop_event = multiprocessing.Event()
-        self.wait_event = multiprocessing.Event()
         self.is_proxy_capable = is_proxy_capable
         self.logger = None
         self.is_instance = False

--- a/src/pykiso/interfaces/simple_auxiliary.py
+++ b/src/pykiso/interfaces/simple_auxiliary.py
@@ -81,18 +81,23 @@ class SimpleAuxiliaryInterface(metaclass=abc.ABCMeta):
         return report
 
     def resume(self) -> None:
-        """Resume current auxiliary's run."""
+        """Resume current auxiliary's run, by running the
+        create_instance method in the background.
+
+        .. warning:: due to the usage of create_instance if an issue
+            occurred the exception AuxiliaryCreationError is raised.
+        """
         if not self.is_instance:
             self.create_instance()
         else:
-            log.error("Cannot resume auxiliary, error occurred during creation")
+            log.warning(f"Auxiliary '{self}' is already running")
 
     def suspend(self) -> None:
         """Suspend current auxiliary's run."""
         if self.is_instance:
             self.delete_instance()
         else:
-            log.error("Cannot suspend auxiliary, error occurred during creation")
+            log.warning(f"Auxiliary '{self}' is already stopped")
 
     def stop(self):
         """Stop the auxiliary"""

--- a/src/pykiso/interfaces/simple_auxiliary.py
+++ b/src/pykiso/interfaces/simple_auxiliary.py
@@ -23,6 +23,7 @@ import abc
 import logging
 from typing import List, Optional
 
+from ..exceptions import AuxiliaryCreationError
 from .thread_auxiliary import AuxiliaryInterface
 
 log = logging.getLogger(__name__)
@@ -62,8 +63,12 @@ class SimpleAuxiliaryInterface(metaclass=abc.ABCMeta):
         """Create an auxiliary instance and ensure the communication to it.
 
         :return: True if creation was successful otherwise False
+
+        :raises AuxiliaryCreationError: if instance creation failed
         """
         self.is_instance = self._create_auxiliary_instance()
+        if not self.is_instance:
+            raise AuxiliaryCreationError(self.name)
         return self.is_instance
 
     def delete_instance(self) -> bool:

--- a/src/pykiso/interfaces/thread_auxiliary.py
+++ b/src/pykiso/interfaces/thread_auxiliary.py
@@ -29,6 +29,7 @@ from typing import List, Optional
 from pykiso.auxiliary import AuxiliaryCommon
 from pykiso.test_setup.dynamic_loader import PACKAGE
 
+from ..exceptions import AuxiliaryCreationError
 from ..types import MsgType
 
 log = logging.getLogger(__name__)
@@ -127,6 +128,8 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
         """Create an auxiliary instance and ensure the communication to it.
 
         :return: message.Message() - Contain received message
+
+        :raises AuxiliaryCreationError: if instance creation failed
         """
         if self.lock.acquire():
             # Trigger the internal requests
@@ -135,6 +138,9 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
             report = self.queue_out.get()
             # Release the above lock
             self.lock.release()
+            # aux instance can't be created just exit
+            if not report:
+                raise AuxiliaryCreationError(self.name)
             # Return the report
             return report
 

--- a/src/pykiso/interfaces/thread_auxiliary.py
+++ b/src/pykiso/interfaces/thread_auxiliary.py
@@ -48,7 +48,6 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
         self,
         name: str = None,
         is_proxy_capable: bool = False,
-        is_pausable: bool = False,
         activate_log: List[str] = None,
         auto_start: bool = True,
     ) -> None:
@@ -57,8 +56,6 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
         :param name: alias of the auxiliary instance
         :param is_proxy_capable: notify if the current auxiliary could
             be (or not) associated to a proxy-auxiliary.
-        :param is_pausable: notify if the current auxiliary could be
-            (or not) paused
         :param activate_log: loggers to deactivate
         :param auto_start: determine if the auxiliayry is automatically
              started (magic import) or manually (by user)
@@ -75,7 +72,6 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
         self.stop_event = threading.Event()
         self.wait_event = threading.Event()
         self.is_proxy_capable = is_proxy_capable
-        self.is_pausable = is_pausable
         # Create state
         self.is_instance = False
         self.auto_start = auto_start
@@ -201,7 +197,7 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
                 log.warning(f"Aux status: {self.__dict__}")
 
             # Step 2: Check if something was received from the aux instance if instance was created
-            if self.is_instance and not self.is_pausable:
+            if self.is_instance:
                 received_message = self._receive_message(timeout_in_s=0)
                 # If yes, send it via the out queue
                 if received_message is not None:
@@ -211,9 +207,6 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
             if not self.is_instance:
                 time.sleep(0.050)
 
-            # If auxiliary instance is created and is pausable
-            if self.is_instance and self.is_pausable:
-                self.wait_event.wait()
         # Thread stop command was set
         log.info("{} was stopped".format(self))
         # Delete auxiliary external instance if not done

--- a/src/pykiso/interfaces/thread_auxiliary.py
+++ b/src/pykiso/interfaces/thread_auxiliary.py
@@ -70,7 +70,6 @@ class AuxiliaryInterface(threading.Thread, AuxiliaryCommon):
         self.queue_in = queue.Queue()
         self.queue_out = queue.Queue()
         self.stop_event = threading.Event()
-        self.wait_event = threading.Event()
         self.is_proxy_capable = is_proxy_capable
         # Create state
         self.is_instance = False

--- a/src/pykiso/lib/auxiliaries/instrument_control_auxiliary/instrument_control_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/instrument_control_auxiliary/instrument_control_auxiliary.py
@@ -226,6 +226,7 @@ class InstrumentControlAuxiliary(SimpleAuxiliaryInterface):
                 log.info("Using default output channel.")
         except Exception:
             log.exception("Unable to safely open the instrument.")
+            return False
         return True
 
     def _delete_auxiliary_instance(self) -> bool:

--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -190,7 +190,6 @@ class BasicTest(unittest.TestCase):
         """Hook method for constructing the test fixture."""
         pass
 
-    # @timeout_decorator.timeout(5) # Timeout of 10 second as generic test-case # TODO: Only working on linux
     @test_app_interaction(
         message_type=message.MessageCommandType.TEST_CASE_RUN, timeout_cmd=5
     )

--- a/src/pykiso/test_coordinator/test_execution.py
+++ b/src/pykiso/test_coordinator/test_execution.py
@@ -49,7 +49,7 @@ class ExitCode(enum.IntEnum):
     ONE_OR_MORE_TESTS_FAILED = 1
     ONE_OR_MORE_TESTS_RAISED_UNEXPECTED_EXCEPTION = 2
     ONE_OR_MORE_TESTS_FAILED_AND_RAISED_UNEXPECTED_EXCEPTION = 3
-    FAILED_AT_AUXILIARY_CREATION = 4
+    AUXILIARY_CREATION_FAILED = 4
 
 
 def create_test_suite(test_suite_dict: Dict) -> test_suite.BasicTestSuite:
@@ -170,7 +170,7 @@ def execute(
     variants: Optional[tuple] = None,
     branch_levels: Optional[tuple] = None,
     pattern_inject: Optional[str] = None,
-    fail_fast: bool = False,
+    failfast: bool = False,
 ) -> int:
     """create test environment base on config
 
@@ -182,7 +182,7 @@ def execute(
     :param pattern_inject: optional pattern that will override
         test_filter_pattern for all suites. Used in test development to
         run specific tests.
-    :param fail_fast: Stop the test run on the first error or failure
+    :param failfast: Stop the test run on the first error or failure
 
     :return: exit code corresponding to the actual tets exeuciton run
         state(tests failed, unexpected exception...)
@@ -216,12 +216,12 @@ def execute(
                 test_runner = xmlrunner.XMLTestRunner(
                     output=junit_output,
                     resultclass=XmlTestResult,
-                    failfast=fail_fast,
+                    failfast=failfast,
                 )
                 result = test_runner.run(all_tests_to_run)
         else:
             test_runner = unittest.TextTestRunner(
-                resultclass=BannerTestResult, failfast=fail_fast
+                resultclass=BannerTestResult, failfast=failfast
             )
             result = test_runner.run(all_tests_to_run)
 
@@ -232,7 +232,7 @@ def execute(
         else:
             exit_code = failure_and_error_handling(result)
     except AuxiliaryCreationError:
-        exit_code = ExitCode.FAILED_AT_AUXILIARY_CREATION
+        exit_code = ExitCode.AUXILIARY_CREATION_FAILED
     except KeyboardInterrupt:
         log.exception("Keyboard Interrupt detected")
         exit_code = ExitCode.ONE_OR_MORE_TESTS_RAISED_UNEXPECTED_EXCEPTION

--- a/src/pykiso/test_coordinator/test_execution.py
+++ b/src/pykiso/test_coordinator/test_execution.py
@@ -33,6 +33,7 @@ from typing import Dict, Optional
 
 import xmlrunner
 
+from ..exceptions import AuxiliaryCreationError
 from . import test_suite
 from .test_result import BannerTestResult
 from .test_xml_result import XmlTestResult
@@ -48,6 +49,7 @@ class ExitCode(enum.IntEnum):
     ONE_OR_MORE_TESTS_FAILED = 1
     ONE_OR_MORE_TESTS_RAISED_UNEXPECTED_EXCEPTION = 2
     ONE_OR_MORE_TESTS_FAILED_AND_RAISED_UNEXPECTED_EXCEPTION = 3
+    FAILED_AT_AUXILIARY_CREATION = 4
 
 
 def create_test_suite(test_suite_dict: Dict) -> test_suite.BasicTestSuite:
@@ -168,6 +170,7 @@ def execute(
     variants: Optional[tuple] = None,
     branch_levels: Optional[tuple] = None,
     pattern_inject: Optional[str] = None,
+    fail_fast: bool = False,
 ) -> int:
     """create test environment base on config
 
@@ -179,6 +182,10 @@ def execute(
     :param pattern_inject: optional pattern that will override
         test_filter_pattern for all suites. Used in test development to
         run specific tests.
+    :param fail_fast: Stop the test run on the first error or failure
+
+    :return: exit code corresponding to the actual tets exeuciton run
+        state(tests failed, unexpected exception...)
     """
     exit_code = ExitCode.ONE_OR_MORE_TESTS_RAISED_UNEXPECTED_EXCEPTION
     is_raised = False
@@ -207,11 +214,15 @@ def execute(
             reports_path.mkdir(exist_ok=True)
             with open(junit_report_path, "wb") as junit_output:
                 test_runner = xmlrunner.XMLTestRunner(
-                    output=junit_output, resultclass=XmlTestResult
+                    output=junit_output,
+                    resultclass=XmlTestResult,
+                    failfast=fail_fast,
                 )
                 result = test_runner.run(all_tests_to_run)
         else:
-            test_runner = unittest.TextTestRunner(resultclass=BannerTestResult)
+            test_runner = unittest.TextTestRunner(
+                resultclass=BannerTestResult, failfast=fail_fast
+            )
             result = test_runner.run(all_tests_to_run)
 
         # if an exception is raised during test suite collections at least
@@ -220,7 +231,8 @@ def execute(
             exit_code = ExitCode.ONE_OR_MORE_TESTS_RAISED_UNEXPECTED_EXCEPTION
         else:
             exit_code = failure_and_error_handling(result)
-
+    except AuxiliaryCreationError:
+        exit_code = ExitCode.FAILED_AT_AUXILIARY_CREATION
     except KeyboardInterrupt:
         log.exception("Keyboard Interrupt detected")
         exit_code = ExitCode.ONE_OR_MORE_TESTS_RAISED_UNEXPECTED_EXCEPTION

--- a/tests/test_dut_auxiliary.py
+++ b/tests/test_dut_auxiliary.py
@@ -366,7 +366,7 @@ def test_resume_with_error(mocker, caplog):
     auxiliary.is_instance = True
     auxiliary.resume()
 
-    assert "Cannot resume auxiliary" in caplog.text
+    assert "is already running" in caplog.text
 
 
 def test_suspend(mocker):
@@ -390,7 +390,7 @@ def test_suspend_with_error(mocker, caplog):
     auxiliary = DUTAuxiliary("channel", "flasher")
     auxiliary.suspend()
 
-    assert "Cannot suspend auxiliary" in caplog.text
+    assert "is already stopped" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simple_auxiliary.py
+++ b/tests/test_simple_auxiliary.py
@@ -90,10 +90,10 @@ def test_resume(mocker, aux_instance):
 def test_resume_error(caplog, aux_instance):
     aux_instance.is_instance = True
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         aux_instance.resume()
 
-    assert "Cannot resume auxiliary" in caplog.text
+    assert "is already running" in caplog.text
 
 
 def test_suspend(mocker, aux_instance):
@@ -111,7 +111,7 @@ def test_suspend(mocker, aux_instance):
 def test_suspend_error(caplog, aux_instance):
     aux_instance.is_instance = False
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         aux_instance.suspend()
 
-    assert "Cannot suspend auxiliary" in caplog.text
+    assert "is already stopped" in caplog.text


### PR DESCRIPTION
- raise the brand new AuxiliaryCreationError exception when the aux instance creation failed
- remove unused timeout decorator
- add --fail-fast flag to cli