### PR TITLE
fix: skip suite tests when setup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ This Changelog can be updated by calling:
 invoke changelog
 ```
 
-## Version 0.18.0 (2022-06-07)
+## Version Unreleased (2022-07-28)
+
+#### Fixes
+
+* skip suite tests when setup fails
+
+Full set of changes: [`0.18.0...5b6f029`](https://github.com/eclipse/kiso-testing/compare/0.18.0...5b6f029)
+
+## Version 0.18.0 (2022-06-08)
 
 #### New Features
 
+* make release 0.18.0 ([#72](https://github.com/eclipse/kiso-testing/issues/72))
 * create base class for test ([#61](https://github.com/eclipse/kiso-testing/issues/61))
 * make the proxy agnostic of transitioning messages
 * add pykiso to pytest tool ([#62](https://github.com/eclipse/kiso-testing/issues/62))

--- a/docs/introduction/integration_test.rst
+++ b/docs/introduction/integration_test.rst
@@ -206,8 +206,14 @@ In order to utilise the SetUp/TearDown test-suite feature, users have to define 
 For each of these classes, the following methods ``test_suite_setUp`` or ``test_suite_tearDown`` must be
 overridden with the behaviour you want to have.
 
-.. note:: Because the python unittest module is used in the background,
-  all methods starting with ``"def test_"`` are executed automatically.
+.. note::
+  | Because the python unittest module is used in the background, all methods
+  | starting with "def test_" are executed automatically
+
+.. note::
+  If a test in SuiteSetup raises an exception, all tests which belong to the
+  same suite_id will be skipped.
+
 
 Find below a full example for a test suite/case declaration :
 

--- a/examples/test_suite_1/test_suite_1.py
+++ b/examples/test_suite_1/test_suite_1.py
@@ -43,6 +43,11 @@ class SuiteSetup(pykiso.RemoteTestSuiteSetup):
     yaml configuration file)
     """
 
+    def test_suite_setUp(self):
+        module = importlib.import_module("pykiso.auxiliaries")
+        attribute = dir(module)
+        logging.error(f"this is the attribute of pykiso.auxiliaries: {attribute}")
+
 
 @pykiso.define_test_parameters(suite_id=1, aux_list=[aux1, aux2])
 class SuiteTearDown(pykiso.RemoteTestSuiteTeardown):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,12 @@ omit = [
 ]
 
 [tool.coverage.report]
-exclude_lines = ["pass", "def __repr__"]
+exclude_lines = [
+    "pass",
+    "def __repr__",
+    "# pragma: no cover",
+    "if TYPE_CHECKING:",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/pykiso/test_coordinator/test_result.py
+++ b/src/pykiso/test_coordinator/test_result.py
@@ -81,10 +81,12 @@ class BannerTestResult(TextTestResult):
         :return: the wrapped docstring
         """
         doc = ""
-        if test._testMethodDoc:
+        if getattr(test, "_testMethodDoc", None) is not None:
             doc = "\n"
             for line in test._testMethodDoc.splitlines():
                 doc += "\n" + textwrap.fill(line.strip(), width=100)
+        else:
+            doc = ""
         return doc
 
     def startTest(self, test: TestCase) -> None:

--- a/src/pykiso/test_coordinator/test_suite.py
+++ b/src/pykiso/test_coordinator/test_suite.py
@@ -20,15 +20,22 @@ gray test-suite for Message Protocol / TestApp usage.
 
 
 """
+from __future__ import annotations
 
 import logging
 import unittest
 from collections.abc import Iterable
-from typing import Callable, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Union
+from unittest.suite import _isnotsuite
 
 from .. import message
 from ..interfaces.thread_auxiliary import AuxiliaryInterface
 from .test_message_handler import test_app_interaction
+
+if TYPE_CHECKING:
+    from unittest.result import TestResult
+
+    from .test_case import BasicTest
 
 __all__ = [
     "BaseTestSuite",
@@ -363,6 +370,72 @@ class BasicTestSuite(unittest.TestSuite):
 
         # add sorted test case list to test suite
         self.addTests(test_case_list)
+
+        self.failed_suite_setups = set()
+
+    def check_suite_setup_failed(self, test: BasicTest, result: TestResult) -> None:
+        """Check if the suite setup has failed and store failed suite id.
+        Search in the global unittest result object, which save all the results
+        of the tests performed up to that point, for a BasicTestSuiteSetup tests
+        which has failed. If the suite setup has failed store the suite id.
+
+        :param test: test to check
+        :param result: unittest result object
+        """
+        if isinstance(test, BasicTestSuiteSetup):
+            for suite_type, _ in result.failures:
+                if isinstance(suite_type, BasicTestSuiteSetup):
+                    self.failed_suite_setups.add(test.test_suite_id)
+
+    def run(self, result: TestResult, debug: bool = False) -> TestResult:
+        """Override run method from unittest.suite.TestSuite.
+        Added functionality:
+        Skip suite tests if the parent test suite setup has failed.
+
+        :param result: unittest result storage
+        :param debug: True to enter debug mode, defaults to False
+        :return: test suite result
+        """
+        topLevel = False
+        if getattr(result, "_testRunEntered", False) is False:
+            result._testRunEntered = topLevel = True
+
+        for index, test in enumerate(self):
+            if result.shouldStop:  # pragma: no cover
+                break
+
+            if _isnotsuite(test):
+                self._tearDownPreviousClass(test, result)
+                self._handleModuleFixture(test, result)
+                self._handleClassSetUp(test, result)
+                result._previousTestClass = test.__class__
+
+                if getattr(test.__class__, "_classSetupFailed", False) or getattr(
+                    result, "_moduleSetUpFailed", False
+                ):  # pragma: no cover
+                    continue
+
+            if not debug:
+                if test.test_suite_id in self.failed_suite_setups:
+                    result.addSkip(
+                        test,
+                        f"Suite Setup failed for test suite {test.test_suite_id}",
+                    )
+                else:
+                    test(result)
+                    self.check_suite_setup_failed(test, result)
+
+            else:  # pragma: no cover
+                test.debug()
+
+            if self._cleanup:
+                self._removeTestAtIndex(index)
+
+        if topLevel:
+            self._tearDownPreviousClass(None, result)
+            self._handleModuleTearDown(result)
+            result._testRunEntered = False
+        return result
 
 
 def tc_sort_key(tc):

--- a/tests/test_test_suite.py
+++ b/tests/test_test_suite.py
@@ -74,8 +74,8 @@ class IntegrationTestSuite(unittest.TestCase):
             result.failures[0][0].id(),
             "fake_suite_1.FakeTestCase-1-0.test_fake_2",
         )
-        self.assertEqual(len(result.skipped), 0)
-        self.assertEqual(result.testsRun, 3)
+        self.assertEqual(len(result.skipped), 1)
+        self.assertEqual(result.testsRun, 2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If multiple suite_ids exist in the pykiso run, only suite child tests with the same suite_id will be skipped when an exception is risen in the SuiteSetup 