### PR TITLE
fix: fix skip test cases of a test suite if a test suite setup fails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: check-yaml
         args: [--unsafe]
     -   id: debug-statements
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8.git
     rev : 3.8.4
     hooks:
       - id: flake8

--- a/src/pykiso/test_coordinator/test_suite.py
+++ b/src/pykiso/test_coordinator/test_suite.py
@@ -378,16 +378,15 @@ class BasicTestSuite(unittest.TestSuite):
     ) -> None:
         """Check if the suite setup has failed and store failed suite id.
         Search in the global unittest result object, which save all the results
-        of the tests performed up to that point, for a BasicTestSuiteSetup tests
-        which has failed. If the suite setup has failed store the suite id.
+        of the tests performed up to that point, if the suite setup that runned
+        has failed then store the suite id.
 
         :param test: test to check
         :param result: unittest result object
         """
         if isinstance(test, BasicTestSuiteSetup):
-            for suite_type, _ in result.failures:
-                if isinstance(suite_type, BasicTestSuiteSetup):
-                    self.failed_suite_setups.add(test.test_suite_id)
+            if result.error_occurred:
+                self.failed_suite_setups.add(test.test_suite_id)
 
     def run(self, result: BannerTestResult, debug: bool = False) -> BannerTestResult:
         """Override run method from unittest.suite.TestSuite.

--- a/src/pykiso/test_result/text_result.py
+++ b/src/pykiso/test_result/text_result.py
@@ -126,6 +126,10 @@ class BannerTestResult(TextTestResult):
         self.width = size.columns - 1
         self.successes: List[Union[BasicTest, BaseTestSuite]] = []
 
+    @property
+    def error_occurred(self):
+        return self._error_occurred
+
     def _banner(
         self, text: Union[List, str], width: Optional[int] = None, sym: str = "#"
     ) -> str:

--- a/tests/test_test_suite.py
+++ b/tests/test_test_suite.py
@@ -16,6 +16,7 @@ import unittest
 import pytest
 
 from pykiso.test_coordinator import test_case, test_suite
+from pykiso.test_result.text_result import BannerTestResult
 
 EX_TEST_CASE = """
 import unittest
@@ -65,7 +66,9 @@ class IntegrationTestSuite(unittest.TestCase):
         self.init.prepare_default_test_suites(
             IntegrationTestSuite.test_suite_directory, "*.py", 1
         )
-        result = unittest.TextTestRunner().run(self.init.custom_test_suite)
+        result = unittest.TextTestRunner(resultclass=BannerTestResult).run(
+            self.init.custom_test_suite
+        )
 
         self.assertEqual(result.wasSuccessful(), False)
         self.assertEqual(len(result.errors), 0)


### PR DESCRIPTION
Fix skipping test cases if a test suite setup fails by looking if an error occurred in the test and then storing it.
I use `result.error_occured` because it is how a test is considered failed or not : https://github.com/eclipse/kiso-testing/blob/master/src/pykiso/test_result/text_result.py#L199