### PR TITLE
fix: change logger name if a serial number is specified

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: check-yaml
         args: [--unsafe]
     -   id: debug-statements
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8.git
     rev : 3.8.4
     hooks:
       - id: flake8

--- a/src/pykiso/lib/connectors/cc_rtt_segger.py
+++ b/src/pykiso/lib/connectors/cc_rtt_segger.py
@@ -121,7 +121,7 @@ class CCRttSegger(connector.CChannel):
         self.rtt_log_refresh_time = round(1 / rtt_log_speed, 6) if rtt_log_speed else 0
         self.rtt_log_thread = threading.Thread(target=self.receive_log)
         self.rtt_log_path = rtt_log_path
-        self.rtt_log = logging.getLogger(f"{__name__}.RTT")
+        self.rtt_log = logging.getLogger(f"{__name__}{serial_number or ''}.RTT")
         if self.rtt_log_path is not None:
             self.rtt_log_buffer_size = 0
             self.rtt_log_path = Path(rtt_log_path)


### PR DESCRIPTION
Fix the issue of mix log with 2 CCRttSegger : the logger is the same object for both connector.
