### PR TITLE
Bugfix/cc vector can snake case serial number

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--unsafe]
     -   id: debug-statements
 -   repo: https://github.com/pycqa/flake8.git
-    rev : 3.8.4
+    rev : 5.0.4
     hooks:
       - id: flake8
         args:

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,6 +70,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "brainstem"
+version = "2.9.24"
+description = "Acroname BrainStem Software Control Package"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cffi = ">=1.0.0"
+
+[[package]]
 name = "bump2version"
 version = "1.0.1"
 description = "Version-bump your software with a single command!"
@@ -84,6 +95,17 @@ description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "cfgv"
@@ -453,6 +475,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -609,7 +639,7 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "python-can"
-version = "4.0.0"
+version = "4.1.0"
 description = "Controller Area Network interface module for Python"
 category = "main"
 optional = false
@@ -622,7 +652,6 @@ pywin32 = {version = "*", markers = "platform_system == \"Windows\" and platform
 setuptools = "*"
 typing-extensions = ">=3.10.0.0"
 uptime = {version = ">=3.0.1,<3.1.0", optional = true, markers = "extra == \"pcan\""}
-windows-curses = {version = "*", markers = "platform_system == \"Windows\" and platform_python_implementation == \"CPython\""}
 wrapt = ">=1.10,<2.0"
 
 [package.extras]
@@ -634,6 +663,7 @@ nixnet = ["nixnet (>=0.3.1)"]
 pcan = ["uptime (>=3.0.1,<3.1.0)"]
 seeedstudio = ["pyserial (>=3.0)"]
 serial = ["pyserial (>=3.0,<4.0)"]
+viewer = ["windows-curses"]
 
 [[package]]
 name = "pytz"
@@ -982,14 +1012,6 @@ docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "
 testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "windows-curses"
-version = "2.3.0"
-description = "Support for the standard curses module on Windows"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "wmctrl"
 version = "0.4"
 description = "A tool to programmatically control windows inside X"
@@ -1020,7 +1042,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "7b1569b28f901a10ccb80d7a613e984585f059ea37771a369579335cd1a0ba97"
+content-hash = "c0afb2bb8cc430e7f1efa3edec3bf905111e51ac2c1f5b51e5e97f188e0e372e"
 
 [metadata.files]
 alabaster = [
@@ -1062,6 +1084,9 @@ black = [
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
     {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
 ]
+brainstem = [
+    {file = "brainstem-2.9.24-py2.py3-none-any.whl", hash = "sha256:9b5159577359f29eb144afc004889b5679c568f1d02092c5c9de3fa02df23cae"},
+]
 bump2version = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
     {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
@@ -1069,6 +1094,72 @@ bump2version = [
 certifi = [
     {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
     {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+]
+cffi = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
@@ -1503,6 +1594,10 @@ psutil = [
     {file = "psutil-5.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:f65f9a46d984b8cd9b3750c2bdb419b2996895b005aefa6cbaba9a143b1ce2c5"},
     {file = "psutil-5.9.1.tar.gz", hash = "sha256:57f1819b5d9e95cdfb0c881a8a5b7d542ed0b7c522d575706a80bedc848c8954"},
 ]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
     {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
@@ -1552,11 +1647,8 @@ pytest-mock = [
     {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
 ]
 python-can = [
-    {file = "python-can-4.0.0.tar.gz", hash = "sha256:59d92846ffb981e634e9e0f2d14a6b4967a875e3869bd2ba168c92c4db6b8b5d"},
-    {file = "python_can-4.0.0-py3-none-any.whl", hash = "sha256:52ffc4f1bb9a585b9ecf53279451fe8266d934428993c580ccf72f9cb321a2e4"},
-    {file = "python_can-4.0.0-py3.7.egg", hash = "sha256:82ed66094cd6d3d6fc0589bc67ca4090af121d7abad58d6754f86abad5e843b1"},
-    {file = "python_can-4.0.0-py3.8.egg", hash = "sha256:6ab63254bdd0e14c8f18b2c55ed3810b3a6395790b28b778dd0112fb0a46e3ce"},
-    {file = "python_can-4.0.0-py3.9.egg", hash = "sha256:60960b715462caabbdcebc3a6a2c573595f2bb58c11d68cd3c3ed402bf2d206d"},
+    {file = "python-can-4.1.0.tar.gz", hash = "sha256:3f2b6b0dc5f459591d171ee0c0136dce79acedc2740ce695024aa3444e911bb9"},
+    {file = "python_can-4.1.0-py3-none-any.whl", hash = "sha256:fe9130564973227bb4649e645f08c830b274233ea5e6b1512abef9d16749ea43"},
 ]
 pytz = [
     {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
@@ -1744,18 +1836,6 @@ urllib3 = [
 virtualenv = [
     {file = "virtualenv-20.16.4-py3-none-any.whl", hash = "sha256:035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22"},
     {file = "virtualenv-20.16.4.tar.gz", hash = "sha256:014f766e4134d0008dcaa1f95bafa0fb0f575795d07cae50b1bee514185d6782"},
-]
-windows-curses = [
-    {file = "windows_curses-2.3.0-cp310-cp310-win32.whl", hash = "sha256:a3a63a0597729e10f923724c2cf972a23ea677b400d2387dee1d668cf7116177"},
-    {file = "windows_curses-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:7a35eda4cb120b9e1a5ae795f3bc06c55b92c9d391baba6be1903285a05f3551"},
-    {file = "windows_curses-2.3.0-cp36-cp36m-win32.whl", hash = "sha256:4d5fb991d1b90a41c2332f02241a1f84c8a1e6bc8f6e0d26f532d0da7a9f7b51"},
-    {file = "windows_curses-2.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:170c0d941c2e0cdf864e7f0441c1bdf0709232bf4aa7ce7f54d90fc76a4c0504"},
-    {file = "windows_curses-2.3.0-cp37-cp37m-win32.whl", hash = "sha256:d5cde8ec6d582aa77af791eca54f60858339fb3f391945f9cad11b1ab71062e3"},
-    {file = "windows_curses-2.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e913dc121446d92b33fe4f5bcca26d3a34e4ad19f2af160370d57c3d1e93b4e1"},
-    {file = "windows_curses-2.3.0-cp38-cp38-win32.whl", hash = "sha256:fbc2131cec57e422c6660e6cdb3420aff5be5169b8e45bb7c471f884b0590a2b"},
-    {file = "windows_curses-2.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cc5fa913780d60f4a40824d374a4f8ca45b4e205546e83a2d85147315a57457e"},
-    {file = "windows_curses-2.3.0-cp39-cp39-win32.whl", hash = "sha256:935be95cfdb9213f6f5d3d5bcd489960e3a8fbc9b574e7b2e8a3a3cc46efff49"},
-    {file = "windows_curses-2.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:c860f596d28377e47f322b7382be4d3573fd76d1292234996bb7f72e0bc0ed0d"},
 ]
 wmctrl = [
     {file = "wmctrl-0.4.tar.gz", hash = "sha256:66cbff72b0ca06a22ec3883ac3a4d7c41078bdae4fb7310f52951769b10e14e0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,11 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+brainstem = "*"
 PyYAML = "^6.0"
 pylink-square = ">=0.12,<0.15"
 pyserial = "^3.0"
-python-can = {version = "^4.0.0", extras = ["pcan"]}
+python-can = {version = "~4.1.0", extras = ["pcan"]}
 PyVISA = "^1.12.0"
 PyVISA-py = "~0.5.3"
 robotframework = "3.2.2"

--- a/src/pykiso/__init__.py
+++ b/src/pykiso/__init__.py
@@ -61,3 +61,5 @@ from .test_coordinator.test_suite import (
     RemoteTestSuiteSetup,
     RemoteTestSuiteTeardown,
 )
+
+logging_initializer.add_internal_log_levels()

--- a/src/pykiso/lib/auxiliaries/udsaux/common/uds_base_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/uds_base_auxiliary.py
@@ -21,7 +21,6 @@ uds_base_auxiliary
 .. currentmodule:: uds_base_auxiliary
 
 """
-import configparser
 import logging
 import warnings
 from pathlib import Path
@@ -35,7 +34,6 @@ from pykiso.interfaces.dt_auxiliary import (
     close_connector,
     open_connector,
 )
-from pykiso.interfaces.thread_auxiliary import AuxiliaryInterface
 
 log = logging.getLogger(__name__)
 

--- a/src/pykiso/lib/connectors/cc_vector_can.py
+++ b/src/pykiso/lib/connectors/cc_vector_can.py
@@ -201,9 +201,9 @@ def detect_serial_number() -> int:
     # Getting all serial numbers
     serial_numbers = set()
     for channel_config in channel_configs:
-        serial_number = channel_config.serialNumber
+        serial_number = channel_config.serial_number
         if serial_number != 0:
-            serial_numbers.add(channel_config.serialNumber)
+            serial_numbers.add(channel_config.serial_number)
     if serial_numbers:
         # if several devices are discovered, the first Vector Box is chosen
         serial_number = min(serial_numbers)

--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -18,7 +18,6 @@ Integration Test Framework
 .. currentmodule:: logging
 
 """
-import collections
 import logging
 import sys
 import time
@@ -28,10 +27,18 @@ from typing import List, NamedTuple, Optional
 from .test_setup.dynamic_loader import PACKAGE
 from .types import PathType
 
-LogOptions = collections.namedtuple(
-    "LogOptions",
-    "log_path log_level report_type verbose",
-)
+
+class LogOptions(NamedTuple):
+    """
+    Namedtuple containing the available options for logging configuration.
+    """
+
+    log_path: PathType
+    log_level: str
+    report_type: str
+    verbose: bool
+
+
 # use to store the selected logging options
 log_options: Optional[LogOptions] = None
 
@@ -42,6 +49,14 @@ def get_logging_options() -> LogOptions:
     :return: logging options log path, log level and report type
     """
     return log_options
+
+
+def add_internal_log_levels() -> None:
+    """Create pykiso's internal log levels if not already done."""
+    if not hasattr(logging, "INTERNAL_WARNING"):
+        add_logging_level("INTERNAL_WARNING", logging.WARNING + 1)
+        add_logging_level("INTERNAL_INFO", logging.INFO + 1)
+        add_logging_level("INTERNAL_DEBUG", logging.DEBUG + 1)
 
 
 def initialize_logging(
@@ -73,9 +88,7 @@ def initialize_logging(
         "ERROR": logging.ERROR,
     }
     # add internal kiso log levels
-    add_logging_level("INTERNAL_WARNING", logging.WARNING + 1)
-    add_logging_level("INTERNAL_INFO", logging.INFO + 1)
-    add_logging_level("INTERNAL_DEBUG", logging.DEBUG + 1)
+    add_internal_log_levels()
 
     # update logging options
     global log_options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,47 +303,6 @@ def mock_tp(mocker):
     return MockTp()
 
 
-def uds_create_config():
-    cfg = """
-[can]
-interface=peak
-canfd=True
-baudrate=500000
-data_baudrate=2000000
-defaultReqId=0xAB
-defaultResId=0xAC
-
-[uds]
-transportProtocol=CAN
-P2_CAN_Client=5
-P2_CAN_Server=1
-
-[canTp]
-reqId=0xAB
-resId=0xAC
-addressingType=NORMAL
-N_SA=0xFF
-N_TA=0xFF
-N_AE=0xFF
-Mtype=DIAGNOSTICS
-discardNegResp=False
-
-[vector]
-channel=1
-appName=MyApp
-    """
-    return cfg
-
-
-@pytest.fixture
-def tmp_uds_config_ini(tmp_path):
-    uds_folder = tmp_path / "fake_uds"
-    uds_folder.mkdir()
-    config_ini = uds_folder / "_config.ini"
-    config_ini.write_text(uds_create_config())
-    return config_ini
-
-
 TestResult.__test__ = False
 
 

--- a/tests/test_cc_vector_can.py
+++ b/tests/test_cc_vector_can.py
@@ -258,7 +258,7 @@ def test_detect_serial_number(mocker, serial_number_list, serial_number_list_emp
             """
             :param serial: serial number of the channel configuration
             """
-            self.serialNumber = serial
+            self.serial_number = serial
 
     # 1) Detection of the lowest serial number in the channels list:
     mocker.patch(

--- a/tests/test_uds_auxiliary.py
+++ b/tests/test_uds_auxiliary.py
@@ -11,6 +11,7 @@ import logging
 from time import sleep
 from unittest import mock
 
+import can
 import pytest
 
 from pykiso.lib.auxiliaries.udsaux.common import UDSCommands
@@ -27,7 +28,7 @@ class TestUdsAuxiliary:
     uds_aux_instance_raw = None
 
     @pytest.fixture(scope="function")
-    def uds_odx_aux_inst(self, mocker, ccpcan_inst, tmp_uds_config_ini):
+    def uds_odx_aux_inst(self, mocker, ccpcan_inst):
 
         mocker.patch(
             "pykiso.interfaces.thread_auxiliary.AuxiliaryInterface.create_instance",
@@ -46,12 +47,12 @@ class TestUdsAuxiliary:
             return_value=True,
         )
         TestUdsAuxiliary.uds_aux_instance_odx = UdsAuxiliary(
-            ccpcan_inst, tmp_uds_config_ini, "odx"
+            ccpcan_inst, odx_file_path="odx"
         )
         return TestUdsAuxiliary.uds_aux_instance_odx
 
     @pytest.fixture(scope="function")
-    def uds_odx_aux_inst_v(self, mocker, ccvector_inst, tmp_uds_config_ini):
+    def uds_odx_aux_inst_v(self, mocker, ccvector_inst):
 
         mocker.patch(
             "pykiso.interfaces.thread_auxiliary.AuxiliaryInterface.create_instance",
@@ -66,12 +67,12 @@ class TestUdsAuxiliary:
             return_value=None,
         )
         TestUdsAuxiliary.uds_aux_instance_odx_v = UdsAuxiliary(
-            ccvector_inst, tmp_uds_config_ini, "odx"
+            ccvector_inst, odx_file_path="odx"
         )
         return TestUdsAuxiliary.uds_aux_instance_odx_v
 
     @pytest.fixture(scope="function")
-    def uds_raw_aux_inst(self, mocker, ccpcan_inst, tmp_uds_config_ini):
+    def uds_raw_aux_inst(self, mocker, ccpcan_inst):
         mocker.patch(
             "pykiso.interfaces.thread_auxiliary.AuxiliaryInterface.create_instance",
             return_value=None,
@@ -84,20 +85,47 @@ class TestUdsAuxiliary:
             "pykiso.interfaces.thread_auxiliary.AuxiliaryInterface.run_command",
             return_value=None,
         )
-        TestUdsAuxiliary.uds_aux_instance_raw = UdsAuxiliary(
-            ccpcan_inst, tmp_uds_config_ini
-        )
+        TestUdsAuxiliary.uds_aux_instance_raw = UdsAuxiliary(ccpcan_inst)
         return TestUdsAuxiliary.uds_aux_instance_raw
 
-    def test_constructor_odx(self, uds_odx_aux_inst, tmp_uds_config_ini):
+    def test_constructor_odx(self, uds_odx_aux_inst):
         assert uds_odx_aux_inst.is_proxy_capable
         assert str(uds_odx_aux_inst.odx_file_path) == "odx"
         assert uds_odx_aux_inst.tp_waiting_time == 0.010
 
-    def test_constructor_raw(self, uds_raw_aux_inst, tmp_uds_config_ini):
+    def test_constructor_raw(self, uds_raw_aux_inst):
         assert uds_raw_aux_inst.is_proxy_capable
         assert uds_raw_aux_inst.odx_file_path is None
         assert uds_raw_aux_inst.tp_waiting_time == 0.010
+
+    def test_constructor_ini_warning(self, ccpcan_inst):
+        with pytest.warns(FutureWarning):
+            UdsAuxiliary(ccpcan_inst, config_ini_path="dummy.ini")
+
+    def test__receive_message(self, uds_raw_aux_inst, mocker):
+        remote_id = 0x42
+        data = bytearray(b"DATA")
+
+        uds_raw_aux_inst.uds_config = mocker.MagicMock()
+
+        uds_raw_aux_inst.channel = mocker.MagicMock()
+        uds_raw_aux_inst.channel.cc_receive.return_value = {
+            "msg": data,
+            "remote_id": remote_id,
+        }
+        uds_raw_aux_inst.res_id = remote_id
+
+        uds_raw_aux_inst._receive_message(timeout_in_s=12)
+
+        uds_raw_aux_inst.uds_config.tp.callback_onReceive.assert_called_once()
+
+        call_arg = uds_raw_aux_inst.uds_config.tp.callback_onReceive.call_args_list[0][
+            0
+        ][0]
+        assert isinstance(call_arg, can.Message)
+        assert call_arg.arbitration_id == remote_id
+        assert call_arg.data == data
+        assert call_arg.is_extended_id == False
 
     def test_send_uds_raw(self, mock_uds_config, uds_odx_aux_inst):
         mock_uds_config.send.return_value = [0x50, 0x03]

--- a/tests/test_uds_server_auxiliary.py
+++ b/tests/test_uds_server_auxiliary.py
@@ -25,7 +25,7 @@ class TestUdsServerAuxiliary:
     uds_aux_instance_raw = None
 
     @pytest.fixture(scope="function")
-    def uds_server_aux_inst(self, mocker, ccpcan_inst, tmp_uds_config_ini):
+    def uds_server_aux_inst(self, mocker, ccpcan_inst):
         mocker.patch(
             "pykiso.interfaces.thread_auxiliary.AuxiliaryInterface.create_instance",
             return_value=None,
@@ -42,17 +42,13 @@ class TestUdsServerAuxiliary:
         TestUdsServerAuxiliary.uds_aux_instance_odx = UdsServerAuxiliary(
             com=ccpcan_inst,
             request_id=0x123,
-            config_ini_path=tmp_uds_config_ini,
             odx_file_path="odx",
         )
         return TestUdsServerAuxiliary.uds_aux_instance_odx
 
-    def test_constructor_no_odx(
-        self, uds_server_aux_inst, tmp_uds_config_ini, ccpcan_inst
-    ):
+    def test_constructor_no_odx(self, uds_server_aux_inst, ccpcan_inst):
         uds_server_inst = UdsServerAuxiliary(
             com=ccpcan_inst,
-            config_ini_path=tmp_uds_config_ini,
             request_id=0x123,
             response_id=0x321,
         )
@@ -62,20 +58,15 @@ class TestUdsServerAuxiliary:
         assert uds_server_inst.req_id == 0x123
         assert uds_server_inst.res_id == 0x321
 
-        uds_server_inst = UdsServerAuxiliary(
-            com=ccpcan_inst, config_ini_path=tmp_uds_config_ini
-        )
+        uds_server_inst = UdsServerAuxiliary(com=ccpcan_inst)
 
         assert uds_server_inst.req_id == None
         assert uds_server_inst.res_id == None
 
-    def test_constructor_odx(
-        self, uds_server_aux_inst, tmp_uds_config_ini, ccpcan_inst, caplog
-    ):
+    def test_constructor_odx(self, uds_server_aux_inst, ccpcan_inst, caplog):
         with caplog.at_level(logging.WARNING):
             uds_server_inst = UdsServerAuxiliary(
                 com=ccpcan_inst,
-                config_ini_path=tmp_uds_config_ini,
                 request_id=0x123,
                 response_id=0x321,
                 odx_file_path="dummy.odx",


### PR DESCRIPTION
- Bump version -> 0.20.2
- Fix vector channel config attribute casing
- Upgrade python-can to 4.1.x
- Add brainstem to dependencies
- Add internal log levels at pykiso import to ensure their presence