### PR TITLE
feat: store activated loggers globally

### DIFF
--- a/docs/whats_new/version_ongoing.rst
+++ b/docs/whats_new/version_ongoing.rst
@@ -1,2 +1,11 @@
 Version ongoing
 ---------------
+
+Remove redundancy of activate_log configuration parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to activate external loggers, it was previously necessary to
+specify their names for each defined auxiliary.
+
+This is no longer the case and specifying them in only one auxiliary
+will be enough for the loggers to stay enabled.


### PR DESCRIPTION
Store activated loggers so that they won't be deactivated by a latter imported auxiliary that does not list this logger in its `activate_log` config param
