### PR TITLE
Bugfix/dash in testcase pattern

### DIFF
--- a/src/pykiso/__init__.py
+++ b/src/pykiso/__init__.py
@@ -40,7 +40,7 @@ from .auxiliary import AuxiliaryCommon
 from .connector import CChannel, Flasher
 from .exceptions import (
     AuxiliaryCreationError,
-    InvalidPattern,
+    InvalidTestModuleName,
     PykisoError,
     TestCollectionError,
 )

--- a/src/pykiso/__init__.py
+++ b/src/pykiso/__init__.py
@@ -40,6 +40,7 @@ from .auxiliary import AuxiliaryCommon
 from .connector import CChannel, Flasher
 from .exceptions import (
     AuxiliaryCreationError,
+    InvalidPattern,
     PykisoError,
     TestCollectionError,
 )

--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -62,11 +62,13 @@ class ConnectorRequiredError(PykisoError):
         super().__init__(self.message)
 
 
-class InvalidPattern(PykisoError):
-    """Raised when a invalid python module name is used as test file pattern by
-    the cli or when parsing the yaml config
+class InvalidTestModuleName(PykisoError):
+    """Raised when a invalid python module name is covered by test file pattern
+    of either the cli or the yaml config
     """
 
-    def __init__(self, pattern: str) -> None:
-        self.message = f"Test file patterns need to be valid python module names but '{pattern}' is invalid"
+    def __init__(self, name: str) -> None:
+        self.message = (
+            f"Test files need to be valid python module names but '{name}' is invalid"
+        )
         super().__init__(self.message)

--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -60,3 +60,13 @@ class ConnectorRequiredError(PykisoError):
         """
         self.message = f"A connector is required for {aux_name} and none is provided"
         super().__init__(self.message)
+
+
+class InvalidPattern(PykisoError):
+    """Raised when a invalid python module name is used as test file pattern by
+    the cli or when parsing the yaml config
+    """
+
+    def __init__(self, pattern: str) -> None:
+        self.message = f"Test file patterns need to be valid python module names but '{pattern}' is invalid"
+        super().__init__(self.message)

--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -70,5 +70,7 @@ class InvalidTestModuleName(PykisoError):
     def __init__(self, name: str) -> None:
         self.message = (
             f"Test files need to be valid python module names but '{name}' is invalid"
+            "\nModule name can only contain letters, numbers, _ (underscore), "
+            "needs to start with a letter or underscore"
         )
         super().__init__(self.message)

--- a/src/pykiso/test_coordinator/test_execution.py
+++ b/src/pykiso/test_coordinator/test_execution.py
@@ -255,6 +255,7 @@ def parse_test_selection_pattern(pattern: str) -> TestFilterPattern:
             parsed_patterns.append(pattern)
     for _ in range(3 - (len(parsed_patterns))):
         parsed_patterns.append(None)
+
     return TestFilterPattern(*parsed_patterns)
 
 
@@ -330,13 +331,13 @@ def execute(
     try:
 
         test_file_pattern = parse_test_selection_pattern(pattern_inject)
-        logging.debug(f"==> parsed test_file_pattern: {test_file_pattern}")
 
         test_suites = collect_test_suites(
             config["test_suite_list"], test_file_pattern.test_file
         )
         # Group all the collected test suites in one global test suite
         all_tests_to_run = unittest.TestSuite(test_suites)
+
         # filter test cases based on variant and branch-level options
         if user_tags:
             apply_tag_filter(all_tests_to_run, user_tags)

--- a/src/pykiso/test_coordinator/test_execution.py
+++ b/src/pykiso/test_coordinator/test_execution.py
@@ -25,7 +25,6 @@ Test Execution
 """
 from __future__ import annotations
 
-import glob
 from typing import TYPE_CHECKING
 from unittest.loader import VALID_MODULE_NAME
 
@@ -267,10 +266,11 @@ def _check_module_names(start_dir: str, pattern: str) -> None:
     :raises InvalidTestModuleName: if a test file name contains a character other
         than letters, numbers, and _ or starts with a number
     """
-    file_names = glob.glob(pathname=pattern, root_dir=start_dir)
-    for file_name in file_names:
-        if not VALID_MODULE_NAME.match(file_name):
-            raise InvalidTestModuleName(file_name)
+    path = Path(start_dir)
+    file_paths = list(path.glob(pattern))
+    for file in file_paths:
+        if not VALID_MODULE_NAME.match(file.name):
+            raise InvalidTestModuleName(file.name)
 
 
 def collect_test_suites(

--- a/src/pykiso/test_coordinator/test_suite.py
+++ b/src/pykiso/test_coordinator/test_suite.py
@@ -378,7 +378,7 @@ class BasicTestSuite(unittest.TestSuite):
     ) -> None:
         """Check if the suite setup has failed and store failed suite id.
         Search in the global unittest result object, which save all the results
-        of the tests performed up to that point, if the suite setup that runned
+        of the tests performed up to that point, if the suite setup that ran
         has failed then store the suite id.
 
         :param test: test to check


### PR DESCRIPTION
To prevent silently skipping tests with incorrect module names, throw an exception if a test_filter_pattern matches a file with an invalid python module name.