### PR TITLE
Feature/include odx configuration in uds server aux

### DIFF
--- a/docs/modules_usage/uds_server_auxiliary.rst
+++ b/docs/modules_usage/uds_server_auxiliary.rst
@@ -346,7 +346,8 @@ valid ODX file, you can use ODX based configuration of callbacks like this (same
 
         def test_run(self):
             """Actual test."""
-            ...
+            # can access the odx based callbacks with readable strings as well:
+            read_software_version = uds_server_auxiliary.callbacks["ReadDataByIdentifier.SoftwareVersion"]
 
         def tearDown(self):
             """Unregister all callbacks registered by the auxiliary."""

--- a/docs/modules_usage/uds_server_auxiliary.rst
+++ b/docs/modules_usage/uds_server_auxiliary.rst
@@ -141,6 +141,11 @@ The available parameters for defining a callback are the following:
 
         odx_response = {"sd_name": "your_data"}
 
+        # for a negative response, the following format is expected:
+        # the key needs to be the string "negative" (case insensitive)
+        # nrc is a uds negative response code as int
+        odx_response = {"Negative": nrc}
+
 - ``response_data`` (optional): the UDS data to send with the response. If the response is specified
     the data is simply appended to the response. This parameter can be passed as an integer or as
     bytes (e.g. ``b"DATA"``).
@@ -300,7 +305,7 @@ Find below an example showing its usage, along with a custom callback function d
                 uds_aux.unregister_callback(callback)
 
 If the :py:class:`~pykiso.lib.auxiliaries.udsaux.uds_server_auxiliary.UdsServerAuxiliary` was configured with a
-valid ODX file, you can use ODX based configuration of callbacks like this:
+valid ODX file, you can use ODX based configuration of callbacks like this (same format as above):
 
 .. code:: python
 

--- a/docs/modules_usage/uds_server_auxiliary.rst
+++ b/docs/modules_usage/uds_server_auxiliary.rst
@@ -29,7 +29,7 @@ It also accepts three optional parameters:
     (overrides the one defined in the config.ini file)
 - ``odx_file_path``: path to the ECU diagnostic definition file in ODX format
 
-.. note:: the configuration through an ODX file is not supported yet.
+.. note:: To configure callbacks from a ODX file you need to use a different format for requests (see UdsCallback below).
 
 Find below a complete configuration example :
 
@@ -122,8 +122,25 @@ The available parameters for defining a callback are the following:
 
 - ``request`` (mandatory): the incoming UDS request on which the corresponding callback should be executed.
     The request can be passed as an integer (e.g. ``0x1003`` or as a list of integers ``[0x10, 0x03]``).
+    If the server has a ODX file specified it is possible to use ODX based callbacks with the following format:
+
+    .. code:: python
+
+        odx_request = {
+            "service": IsoServices.ReadDataByIdentifier,  # the SID
+            "data": {
+                "parameter": "sd_name"  # name of the data point in the <SD> element
+            }
+        }
+
 - ``response`` (optional): the UDS response to send if the registered request is received.
     Passed format is the same as for the request parameter.
+    If the server has a ODX file specified, you can also use a ODX based format as response:
+
+    .. code:: python
+
+        odx_response = {"sd_name": "your_data"}
+
 - ``response_data`` (optional): the UDS data to send with the response. If the response is specified
     the data is simply appended to the response. This parameter can be passed as an integer or as
     bytes (e.g. ``b"DATA"``).
@@ -281,6 +298,57 @@ Find below an example showing its usage, along with a custom callback function d
 
             for callback in uds_aux.callbacks:
                 uds_aux.unregister_callback(callback)
+
+If the :py:class:`~pykiso.lib.auxiliaries.udsaux.uds_server_auxiliary.UdsServerAuxiliary` was configured with a
+valid ODX file, you can use ODX based configuration of callbacks like this:
+
+.. code:: python
+
+    import typing
+
+    import pykiso
+    from pykiso.auxiliaries import uds_aux
+
+
+    @pykiso.define_test_parameters(suite_id=1, case_id=1, aux_list=[uds_aux])
+    class ExampleUdsServerTest(pykiso.BasicTest):
+
+        def setUp(self):
+            """Register various callbacks for the test."""
+            # handle extended diagnostics session request
+            # respond to an incoming request with default [0x50, 0x03]
+            uds_aux.register_callback(
+                request={
+                    "service": IsoServices.DiagnosticSessionControl,
+                    "data": {
+                        "parameter": "Extended_DiagnosticSession"
+                    }
+                }
+            )
+            odx_callback = UdsCallback(
+                request={
+                    "service": IsoServices.ReadDataByIdentifier,
+                    "data": {
+                        "parameter": "SoftwareVersion"
+                },
+                response={"SoftwareVersion": "1.33.7"}
+            )
+            # handle incoming read data by identifier request with identifier parsed from ODX,
+            # e.g. [0x22, 0xA4, 0x55]
+            # the response will be built by:
+            # - creating the positive response corresponding to the request: 0x62A455312E33332E37
+            uds_aux.register_callback(odx_callback)
+
+        def test_run(self):
+            """Actual test."""
+            ...
+
+        def tearDown(self):
+            """Unregister all callbacks registered by the auxiliary."""
+
+            for callback in uds_aux.callbacks:
+                uds_aux.unregister_callback(callback)
+
 
 Accessing UDS callbacks
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/test_odx/odx_min_example.odx
+++ b/examples/test_odx/odx_min_example.odx
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ODX MODEL-VERSION="2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
+    <DIAG-LAYER-CONTAINER>
+        <PROTOCOLS>
+            <PROTOCOL ID="1">
+                <SHORT-NAME>CAN_FD</SHORT-NAME>
+                <LONG-NAME>CAN FD</LONG-NAME>
+                <COMPARAM-SPEC-REF ID-REF="ISO_15765_3_on_ISO_15765_2" DOCREF="ISO_15765_3_on_ISO_15765_2" DOCTYPE="COMPARAM-SPEC"/>
+            </PROTOCOL>
+        </PROTOCOLS>
+        <BASE-VARIANTS>
+            <BASE-VARIANT ID="ECUXXX">
+                <SHORT-NAME>ECUxxx</SHORT-NAME>
+                <LONG-NAME>ECUxxx</LONG-NAME>
+                <DIAG-DATA-DICTIONARY-SPEC>
+                    <DATA-OBJECT-PROPS>
+                        <DATA-OBJECT-PROP ID="3">
+                            <SHORT-NAME>Software_Version</SHORT-NAME>
+                            <LONG-NAME>Software_Version</LONG-NAME>
+                            <COMPU-METHOD>
+                                <CATEGORY>IDENTICAL</CATEGORY>
+                            </COMPU-METHOD>
+                            <DIAG-CODED-TYPE BASE-TYPE-ENCODING="ISO-8859-1" BASE-DATA-TYPE="A_ASCIISTRING" xsi:type="STANDARD-LENGTH-TYPE">
+                                <BIT-LENGTH>128</BIT-LENGTH>
+                            </DIAG-CODED-TYPE>
+                            <PHYSICAL-TYPE BASE-DATA-TYPE="A_UNICODE2STRING"/>
+                        </DATA-OBJECT-PROP>
+                    </DATA-OBJECT-PROPS>
+                    <STRUCTURES>
+                        <STRUCTURE>
+                        </STRUCTURE>
+                    </STRUCTURES>
+                </DIAG-DATA-DICTIONARY-SPEC>
+                <DIAG-COMMS>
+                    <DIAG-SERVICE ID="6" SEMANTIC="IDENTIFICATION">
+                        <SHORT-NAME>SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>SoftwareVersion Read</LONG-NAME>
+                        <SDGS>
+                            <SDG>
+                                <SDG-CAPTION ID="7">
+                                    <SHORT-NAME>CANdelaServiceInformation</SHORT-NAME>
+                                </SDG-CAPTION>
+                                <SD SI="DiagInstanceQualifier">SoftwareVersion</SD>
+                                <SD SI="DiagInstanceName">SoftwareVersion</SD>
+                                <SD SI="ServiceQualifier">Read</SD>
+                                <SD SI="ServiceName">Read</SD>
+                                <SD SI="PositiveResponseSuppressed">no</SD>
+                            </SDG>
+                        </SDGS>
+                        <AUDIENCE IS-SUPPLIER="false" IS-DEVELOPMENT="false" IS-MANUFACTURING="false" IS-AFTERSALES="false" IS-AFTERMARKET="false"/>
+                        <REQUEST-REF ID-REF="9"/>
+                        <POS-RESPONSE-REFS>
+                            <POS-RESPONSE-REF ID-REF="10"/>
+                        </POS-RESPONSE-REFS>
+                        <NEG-RESPONSE-REFS>
+                            <NEG-RESPONSE-REF ID-REF="11"/>
+                        </NEG-RESPONSE-REFS>
+                    </DIAG-SERVICE>
+                </DIAG-COMMS>
+                <REQUESTS>
+                    <REQUEST ID="9">
+                        <SHORT-NAME>RQ_SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>RQ SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_RQ</SHORT-NAME>
+                                <LONG-NAME>SID-RQ</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>34</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
+                                <LONG-NAME>Identifier</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>42069</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>16</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                        </PARAMS>
+                    </REQUEST>
+                </REQUESTS>
+                <POS-RESPONSES>
+                    <POS-RESPONSE ID="10">
+                        <SHORT-NAME>PR_SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>PR SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_PR</SHORT-NAME>
+                                <LONG-NAME>SID-PR</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>98</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
+                                <LONG-NAME>Identifier</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>42069</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>16</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="VALUE">
+                                <SHORT-NAME>SoftwareVersion</SHORT-NAME>
+                                <LONG-NAME>SoftwareVersion</LONG-NAME>
+                                <BYTE-POSITION>3</BYTE-POSITION>
+                                <DOP-REF ID-REF="3"/>
+                            </PARAM>
+                        </PARAMS>
+                    </POS-RESPONSE>
+                </POS-RESPONSES>
+                <NEG-RESPONSES>
+                    <NEG-RESPONSE ID="11">
+                        <SHORT-NAME>NR_SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>NR SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_NR</SHORT-NAME>
+                                <LONG-NAME>SID-NR</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>127</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="SERVICEIDRQ" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SIDRQ_NR</SHORT-NAME>
+                                <LONG-NAME>SIDRQ-NR</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>34</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="VALUE">
+                                <SHORT-NAME>Read</SHORT-NAME>
+                                <LONG-NAME>Read</LONG-NAME>
+                                <BYTE-POSITION>2</BYTE-POSITION>
+                                <DOP-REF ID-REF="13"/>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="NRC-CONST">
+                                <SHORT-NAME>NRCConst_Read</SHORT-NAME>
+                                <LONG-NAME>Read</LONG-NAME>
+                                <BYTE-POSITION>2</BYTE-POSITION>
+                                <CODED-VALUES>
+                                    <CODED-VALUE>19</CODED-VALUE>
+                                    <CODED-VALUE>20</CODED-VALUE>
+                                    <CODED-VALUE>34</CODED-VALUE>
+                                    <CODED-VALUE>49</CODED-VALUE>
+                                    <CODED-VALUE>51</CODED-VALUE>
+                                </CODED-VALUES>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                        </PARAMS>
+                    </NEG-RESPONSE>
+                </NEG-RESPONSES>
+                <GLOBAL-NEG-RESPONSES>
+                    <GLOBAL-NEG-RESPONSE ID="14">
+                    </GLOBAL-NEG-RESPONSE>
+                </GLOBAL-NEG-RESPONSES>
+            </BASE-VARIANT>
+        </BASE-VARIANTS>
+    </DIAG-LAYER-CONTAINER>
+</ODX>

--- a/examples/test_odx/odx_min_example.odx
+++ b/examples/test_odx/odx_min_example.odx
@@ -26,6 +26,17 @@
                             </DIAG-CODED-TYPE>
                             <PHYSICAL-TYPE BASE-DATA-TYPE="A_UNICODE2STRING"/>
                         </DATA-OBJECT-PROP>
+                        <DATA-OBJECT-PROP ID="103">
+                            <SHORT-NAME>Hardware_Version</SHORT-NAME>
+                            <LONG-NAME>Hardware_Version</LONG-NAME>
+                            <COMPU-METHOD>
+                                <CATEGORY>IDENTICAL</CATEGORY>
+                            </COMPU-METHOD>
+                            <DIAG-CODED-TYPE BASE-TYPE-ENCODING="ISO-8859-1" BASE-DATA-TYPE="A_ASCIISTRING" xsi:type="STANDARD-LENGTH-TYPE">
+                                <BIT-LENGTH>24</BIT-LENGTH>
+                            </DIAG-CODED-TYPE>
+                            <PHYSICAL-TYPE BASE-DATA-TYPE="A_UNICODE2STRING"/>
+                        </DATA-OBJECT-PROP>
                     </DATA-OBJECT-PROPS>
                     <STRUCTURES>
                         <STRUCTURE>
@@ -57,6 +68,30 @@
                             <NEG-RESPONSE-REF ID-REF="11"/>
                         </NEG-RESPONSE-REFS>
                     </DIAG-SERVICE>
+                    <DIAG-SERVICE ID="106" SEMANTIC="IDENTIFICATION">
+                        <SHORT-NAME>HardwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>HardwareVersion Read</LONG-NAME>
+                        <SDGS>
+                            <SDG>
+                                <SDG-CAPTION ID="107">
+                                    <SHORT-NAME>CANdelaServiceInformation</SHORT-NAME>
+                                </SDG-CAPTION>
+                                <SD SI="DiagInstanceQualifier">HardwareVersion</SD>
+                                <SD SI="DiagInstanceName">HardwareVersion</SD>
+                                <SD SI="ServiceQualifier">Read</SD>
+                                <SD SI="ServiceName">Read</SD>
+                                <SD SI="PositiveResponseSuppressed">no</SD>
+                            </SDG>
+                        </SDGS>
+                        <AUDIENCE IS-SUPPLIER="false" IS-DEVELOPMENT="false" IS-MANUFACTURING="false" IS-AFTERSALES="false" IS-AFTERMARKET="false"/>
+                        <REQUEST-REF ID-REF="109"/>
+                        <POS-RESPONSE-REFS>
+                            <POS-RESPONSE-REF ID-REF="110"/>
+                        </POS-RESPONSE-REFS>
+                        <NEG-RESPONSE-REFS>
+                            <NEG-RESPONSE-REF ID-REF="111"/>
+                        </NEG-RESPONSE-REFS>
+                    </DIAG-SERVICE>
                 </DIAG-COMMS>
                 <REQUESTS>
                     <REQUEST ID="9">
@@ -77,6 +112,30 @@
                                 <LONG-NAME>Identifier</LONG-NAME>
                                 <BYTE-POSITION>1</BYTE-POSITION>
                                 <CODED-VALUE>42069</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>16</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                        </PARAMS>
+                    </REQUEST>
+                    <REQUEST ID="109">
+                        <SHORT-NAME>RQ_HardwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>RQ HardwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_RQ</SHORT-NAME>
+                                <LONG-NAME>SID-RQ</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>34</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
+                                <LONG-NAME>Identifier</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>42070</CODED-VALUE>
                                 <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
                                     <BIT-LENGTH>16</BIT-LENGTH>
                                 </DIAG-CODED-TYPE>
@@ -115,11 +174,86 @@
                             </PARAM>
                         </PARAMS>
                     </POS-RESPONSE>
+                    <POS-RESPONSE ID="110">
+                        <SHORT-NAME>PR_HardwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>PR HardwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_PR</SHORT-NAME>
+                                <LONG-NAME>SID-PR</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>98</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
+                                <LONG-NAME>Identifier</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>42070</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>16</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="VALUE">
+                                <SHORT-NAME>HardwareVersion</SHORT-NAME>
+                                <LONG-NAME>HardwareVersion</LONG-NAME>
+                                <BYTE-POSITION>3</BYTE-POSITION>
+                                <DOP-REF ID-REF="103"/>
+                            </PARAM>
+                        </PARAMS>
+                    </POS-RESPONSE>
                 </POS-RESPONSES>
                 <NEG-RESPONSES>
                     <NEG-RESPONSE ID="11">
                         <SHORT-NAME>NR_SoftwareVersion_Read</SHORT-NAME>
                         <LONG-NAME>NR SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_NR</SHORT-NAME>
+                                <LONG-NAME>SID-NR</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>127</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="SERVICEIDRQ" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SIDRQ_NR</SHORT-NAME>
+                                <LONG-NAME>SIDRQ-NR</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>34</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="VALUE">
+                                <SHORT-NAME>Read</SHORT-NAME>
+                                <LONG-NAME>Read</LONG-NAME>
+                                <BYTE-POSITION>2</BYTE-POSITION>
+                                <DOP-REF ID-REF="13"/>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="NRC-CONST">
+                                <SHORT-NAME>NRCConst_Read</SHORT-NAME>
+                                <LONG-NAME>Read</LONG-NAME>
+                                <BYTE-POSITION>2</BYTE-POSITION>
+                                <CODED-VALUES>
+                                    <CODED-VALUE>19</CODED-VALUE>
+                                    <CODED-VALUE>20</CODED-VALUE>
+                                    <CODED-VALUE>34</CODED-VALUE>
+                                    <CODED-VALUE>49</CODED-VALUE>
+                                    <CODED-VALUE>51</CODED-VALUE>
+                                </CODED-VALUES>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                        </PARAMS>
+                    </NEG-RESPONSE>
+                    <NEG-RESPONSE ID="111">
+                        <SHORT-NAME>NR_HardwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>NR HardwareVersion Read</LONG-NAME>
                         <PARAMS>
                             <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
                                 <SHORT-NAME>SID_NR</SHORT-NAME>

--- a/examples/test_odx/test_client_odx.py
+++ b/examples/test_odx/test_client_odx.py
@@ -1,0 +1,31 @@
+import logging
+import time
+import typing
+import unittest
+
+import pykiso
+from pykiso.auxiliaries import uds_client_aux
+
+# helper objects to build callbacks can be imported from the pykiso lib
+from pykiso.lib.auxiliaries.udsaux import UdsCallback, UdsServerAuxiliary
+
+
+@pykiso.define_test_parameters(suite_id=1, case_id=1, aux_list=[uds_client_aux])
+class ExampleUdsServerTest(pykiso.BasicTest):
+    def setUp(self):
+        pass
+
+    def test_run(self):
+        """
+        sent a request to a uds server
+        """
+        logging.info(
+            f"--------------- RUN: {self.test_suite_id}, {self.test_case_id} ---------------"
+        )
+        response = uds_client_aux.send_uds_raw([0x10, 0x03])
+        assert response == [0x50, 0x03]
+        response_2 = uds_client_aux.send_uds_raw([0x22, 0xA4, 0x55])
+        assert response_2 == [0x62, 0xA4, 0x55]
+
+    def tearDown(self):
+        pass

--- a/examples/test_odx/test_client_odx.py
+++ b/examples/test_odx/test_client_odx.py
@@ -25,7 +25,10 @@ class ExampleUdsServerTest(pykiso.BasicTest):
         response = uds_client_aux.send_uds_raw([0x10, 0x03])
         assert response == [0x50, 0x03]
         response_2 = uds_client_aux.send_uds_raw([0x22, 0xA4, 0x55])
-        assert response_2 == [0x62, 0xA4, 0x55]
+        # negative:
+        assert response_2 == [0x7F, 0x22, 0x11]
+        # positive:
+        # assert response_2 == [0x62, 0xA4, 0x55, 0x30, 0x2E, 0x31, 0x37, 0x2E, 0x30]
 
     def tearDown(self):
         pass

--- a/examples/test_odx/test_client_odx.py
+++ b/examples/test_odx/test_client_odx.py
@@ -1,13 +1,27 @@
+##########################################################################
+# Copyright (c) 2010-2023 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+##########################################################################
+
+"""
+UDS server auxiliary simple example
+***********************************
+
+:module: test_client_odx
+
+:synopsis: Example test to use with odx configured uds server
+    Showcases negative and positive responses
+
+.. currentmodule:: test_client_odx
+"""
 import logging
-import time
-import typing
-import unittest
 
 import pykiso
 from pykiso.auxiliaries import uds_client_aux
-
-# helper objects to build callbacks can be imported from the pykiso lib
-from pykiso.lib.auxiliaries.udsaux import UdsCallback, UdsServerAuxiliary
 
 
 @pykiso.define_test_parameters(suite_id=1, case_id=1, aux_list=[uds_client_aux])
@@ -17,18 +31,17 @@ class ExampleUdsServerTest(pykiso.BasicTest):
 
     def test_run(self):
         """
-        sent a request to a uds server
+        Send two uds requests, expecting one negative and one positive response
         """
         logging.info(
             f"--------------- RUN: {self.test_suite_id}, {self.test_case_id} ---------------"
         )
-        response = uds_client_aux.send_uds_raw([0x10, 0x03])
-        assert response == [0x50, 0x03]
-        response_2 = uds_client_aux.send_uds_raw([0x22, 0xA4, 0x55])
-        # negative:
-        assert response_2 == [0x7F, 0x22, 0x11]
-        # positive:
-        # assert response_2 == [0x62, 0xA4, 0x55, 0x30, 0x2E, 0x31, 0x37, 0x2E, 0x30]
+        # test a expected negative response:
+        negative_response = uds_client_aux.send_uds_raw([0x22, 0xA4, 0x55])
+        assert negative_response == [0x7F, 0x22, 0x11]
+        # test a expected positive response:
+        positive_response = uds_client_aux.send_uds_raw([0x22, 0xA4, 0x56])
+        assert positive_response == [0x62, 0xA4, 0x56, 0x31, 0x32, 0x33]
 
     def tearDown(self):
         pass

--- a/examples/test_odx/test_server_odx.py
+++ b/examples/test_odx/test_server_odx.py
@@ -1,0 +1,62 @@
+import logging
+import time
+import typing
+import unittest
+from copy import copy
+
+from uds import IsoServices
+
+import pykiso
+from pykiso.auxiliaries import uds_server_aux
+
+# helper objects to build callbacks can be imported from the pykiso lib
+from pykiso.lib.auxiliaries.udsaux import UdsCallback, UdsServerAuxiliary
+
+UDS_CALLBACKS = [
+    UdsCallback(request=0x1003, response=0x5003),
+    UdsCallback(
+        request={
+            "service": IsoServices.ReadDataByIdentifier,
+            "data": {"parameter": "SoftwareVersion"},
+        },
+        # response={"SoftwareVersion": "0.17.0"},
+    ),
+]
+
+
+@pykiso.define_test_parameters(suite_id=1, case_id=1, aux_list=[uds_server_aux])
+class ExampleUdsServerTest(pykiso.BasicTest):
+    def setUp(self):
+        """Register various callbacks for the test."""
+        # register all callbacks defined above
+        for callback in UDS_CALLBACKS:
+            uds_server_aux.register_callback(callback)
+        logging.info("-----> Waiting for requests")
+
+    def test_run(self):
+        """
+        Simply wait a bit and expect the registered request to be received
+        (and the corresponding response to be sent to the client).
+        """
+        logging.info(
+            f"--------------- RUN: {self.test_suite_id}, {self.test_case_id} ---------------"
+        )
+        time.sleep(10)
+        # access the previously registered callback
+        extended_diag_session_callback = uds_server_aux.callbacks["0x1003"]
+        self.assertGreater(
+            extended_diag_session_callback.call_count,
+            0,
+            "Expected UDS request was not sent by the client after 10s",
+        )
+        read_by_id_callback = uds_server_aux.callbacks["0x22A455"]
+        self.assertGreater(
+            read_by_id_callback.call_count,
+            0,
+            "Expected ODX UDS request was not sent by the client after 10s",
+        )
+
+    def tearDown(self):
+        """Unregister all previously registered callbacks."""
+        for callback in uds_server_aux.callbacks.copy():
+            uds_server_aux.unregister_callback(callback)

--- a/examples/test_odx/test_server_odx.py
+++ b/examples/test_odx/test_server_odx.py
@@ -70,12 +70,15 @@ class ExampleUdsServerTest(pykiso.BasicTest):
         )
         time.sleep(5)
         # access the previously registered callback
-        read_software_version = uds_server_aux.callbacks["0x22A455"]
+        read_software_version = uds_server_aux.callbacks[
+            "ReadDataByIdentifier.SoftwareVersion"
+        ]
         self.assertGreater(
             read_software_version.call_count,
             0,
             "Expected ODX UDS request was not sent by the client after 10s",
         )
+
         read_hardware_version = uds_server_aux.callbacks["0x22A456"]
         self.assertGreater(
             read_hardware_version.call_count,

--- a/examples/test_odx/test_server_odx.py
+++ b/examples/test_odx/test_server_odx.py
@@ -11,15 +11,26 @@ from pykiso.auxiliaries import uds_server_aux
 
 # helper objects to build callbacks can be imported from the pykiso lib
 from pykiso.lib.auxiliaries.udsaux import UdsCallback, UdsServerAuxiliary
+from pykiso.lib.auxiliaries.udsaux.common.uds_response import (
+    NegativeResponseCode,
+)
 
 UDS_CALLBACKS = [
     UdsCallback(request=0x1003, response=0x5003),
+    # UdsCallback(
+    #     request={
+    #         "service": IsoServices.ReadDataByIdentifier,
+    #         "data": {"parameter": "SoftwareVersion"},
+    #     },
+    #     # also works without response
+    #     response={"SoftwareVersion": "0.17.0"},
+    # ),
     UdsCallback(
         request={
             "service": IsoServices.ReadDataByIdentifier,
             "data": {"parameter": "SoftwareVersion"},
         },
-        # response={"SoftwareVersion": "0.17.0"},
+        response={"NEGATIVE": NegativeResponseCode.SERVICE_NOT_SUPPORTED},
     ),
 ]
 
@@ -41,7 +52,7 @@ class ExampleUdsServerTest(pykiso.BasicTest):
         logging.info(
             f"--------------- RUN: {self.test_suite_id}, {self.test_case_id} ---------------"
         )
-        time.sleep(10)
+        time.sleep(5)
         # access the previously registered callback
         extended_diag_session_callback = uds_server_aux.callbacks["0x1003"]
         self.assertGreater(

--- a/examples/test_odx_client.yaml
+++ b/examples/test_odx_client.yaml
@@ -1,0 +1,20 @@
+auxiliaries:
+  uds_client_aux:
+    connectors:
+      com: can_channel
+    config:
+      odx_file_path: ~
+      request_id: 0xB0
+      response_id: 0xB1
+    type: pykiso.lib.auxiliaries.udsaux.uds_auxiliary:UdsAuxiliary
+connectors:
+  can_channel:
+    config:
+      interface: "pcan"
+      channel: "PCAN_USBBUS1"
+      state: "ACTIVE"
+    type: pykiso.lib.connectors.cc_pcan_can:CCPCanCan
+test_suite_list:
+  - suite_dir: ./test_odx
+    test_filter_pattern: "test_client_odx.py"
+    test_suite_id: 1

--- a/examples/test_odx_server.yaml
+++ b/examples/test_odx_server.yaml
@@ -1,0 +1,20 @@
+auxiliaries:
+  uds_server_aux:
+    connectors:
+      com: can_channel
+    config:
+      odx_file_path: "./test_odx/odx_min_example.odx"
+      request_id: 0xB1
+      response_id: 0xB0
+    type: pykiso.lib.auxiliaries.udsaux.uds_server_auxiliary:UdsServerAuxiliary
+connectors:
+  can_channel:
+    config:
+      interface: "pcan"
+      channel: "PCAN_USBBUS2"
+      state: "ACTIVE"
+    type: pykiso.lib.connectors.cc_pcan_can:CCPCanCan
+test_suite_list:
+  - suite_dir: ./test_odx
+    test_filter_pattern: "test_server_odx.py"
+    test_suite_id: 1

--- a/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
@@ -12,6 +12,9 @@ ODX Parser for UDS Server Auxiliary
 
 :module: odx_parser
 
+:synopsis: odx parser used by a uds server to dynamically configure its
+    uds callbacks from an odx file
+
 .. currentmodule:: odx_parser
 
 """
@@ -42,7 +45,7 @@ class OdxParser:
     def _find_element_by_odx_id(self, odx_id: str) -> Element:
         """Find an odx element by the given id
 
-        :id: odx id of the element to search for
+        :param id: odx id of the element to search for
         :raises ValueError: if no element with given odx id found
         :return: the element with the given odx id
         """
@@ -55,7 +58,7 @@ class OdxParser:
     def _find_diag_services_by_sd(self, sd_instance_name: str) -> Element:
         """Find the <DIAG-SERVICE> with the given sd_instance_name
 
-        :sd_instance_name: content of the <SD SI="DiagInstanceName">
+        :param sd_instance_name: content of the <SD SI="DiagInstanceName">
         :return: the parent diag service odx element of the sd element with given name
         """
         # xpath to diag service for given sd instance name
@@ -71,9 +74,9 @@ class OdxParser:
     ) -> List[int]:
         """Get the list of coded values for a ODX request element to construct a UDS request from
 
-        :sd: sd instance name
-        :sid: service id to differentiate between diag services with the same sd name
-        :raise ValueError: if no request could be created for the given sd name and SID
+        :param sd: sd instance name
+        :param sid: service id to differentiate between diag services with the same sd name
+        :raises ValueError: if no request could be created for the given sd name and SID
         :return: a list of the coded values to be converted into a uds request
         """
         diag_services = self._find_diag_services_by_sd(sd)

--- a/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
@@ -26,12 +26,11 @@ from xml.etree.ElementTree import Element
 log = logging.getLogger(__name__)
 
 
-class ODXParser:
+class OdxParser:
     def __init__(self, odx_file: Path) -> None:
         with open(odx_file) as odx:
             # create a xml tree from root <ODX>
             self.odx_tree = ElementTree.parse(odx)
-        log.internal_debug("Instantiated ODX Parser")
 
     def _find_element_by_odx_id(self, odx_id: str) -> Element:
         """Find an odx element by the given id
@@ -54,11 +53,11 @@ class ODXParser:
         """
         # xpath to diag service for given sd instance name
         diag_service = self.odx_tree.find(f".//SD[@SI][.='{sd_instance_name}']../../..")
+        if diag_service is None:
+            raise ValueError(f"No DIAG-SERVICE has a SD containing {sd_instance_name}")
         log.internal_debug(
             f"Found {diag_service}, short-name={diag_service.find('SHORT-NAME').text}"
         )
-        if diag_service is None:
-            raise ValueError(f"No DIAG-SERVICE has a SD containing {sd_instance_name}")
         return diag_service
 
     def get_coded_values_by_sd(self, sd: str) -> List[int]:

--- a/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
@@ -27,6 +27,8 @@ log = logging.getLogger(__name__)
 
 
 class OdxParser:
+    """Used to parse ODX files to configure a Uds server"""
+
     def __init__(self, odx_file: Path) -> None:
         with open(odx_file) as odx:
             # create a xml tree from root <ODX>
@@ -57,13 +59,14 @@ class OdxParser:
         )
         if not diag_services:
             raise ValueError(f"No DIAG-SERVICE has a SD containing {sd_instance_name}")
-        log.internal_debug(f"Found {len(diag_services)} potential diag services")
         return diag_services
 
     def get_coded_values(self, sd: str, sid: int) -> List[int]:
         """Get the list of coded values for a ODX request element to construct a UDS request from
 
         :sd: sd instance name
+        :sid: service id to differentiate between diag services with the same sd name
+        :raise ValueError: if no request could be created for the given sd name and SID
         :return: a list of the coded values to be converted into a uds request
         """
         diag_services = self._find_diag_services_by_sd(sd)

--- a/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/odx_parser.py
@@ -1,0 +1,81 @@
+##########################################################################
+# Copyright (c) 2010-2023 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+##########################################################################
+"""
+ODX Parser for UDS Server Auxiliary
+***********************************
+
+:module: odx_parser
+
+.. currentmodule:: odx_parser
+
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+
+log = logging.getLogger(__name__)
+
+
+class ODXParser:
+    def __init__(self, odx_file: Path) -> None:
+        with open(odx_file) as odx:
+            # create a xml tree from root <ODX>
+            self.odx_tree = ElementTree.parse(odx)
+        log.internal_debug("Instantiated ODX Parser")
+
+    def _find_element_by_odx_id(self, odx_id: str) -> Element:
+        """Find an odx element by the given id
+
+        :id: odx id of the element to search for
+        :raises ValueError: if no element with given odx id found
+        :return: the element with the given odx id
+        """
+        # xpath finding the element with the given id
+        element = self.odx_tree.find(f".//*[@ID='{odx_id}']")
+        if element is None:
+            raise ValueError(f"No element with id={odx_id} found")
+        return element
+
+    def _find_diag_service_by_sd(self, sd_instance_name: str) -> Element:
+        """Find the <DIAG-SERVICE> with the given sd_instance_name
+
+        :sd_instance_name: content of the <SD SI="DiagInstanceName">
+        :return: the parent diag service odx element of the sd element with given name
+        """
+        # xpath to diag service for given sd instance name
+        diag_service = self.odx_tree.find(f".//SD[@SI][.='{sd_instance_name}']../../..")
+        log.internal_debug(
+            f"Found {diag_service}, short-name={diag_service.find('SHORT-NAME').text}"
+        )
+        if diag_service is None:
+            raise ValueError(f"No DIAG-SERVICE has a SD containing {sd_instance_name}")
+        return diag_service
+
+    def get_coded_values_by_sd(self, sd: str) -> List[int]:
+        """Get the list of coded values for a ODX request element to construct a UDS request from
+
+        :sd: sd instance name
+        :return: a list of the coded values to be converted into a uds request
+        """
+        log.internal_debug("Parsing coded values for request sd")
+        diag_service = self._find_diag_service_by_sd(sd)
+        request_id = diag_service.find(".//REQUEST-REF").attrib["ID-REF"]
+        request_element = self._find_element_by_odx_id(request_id)
+        coded_value_elements = request_element.findall(".//CODED-VALUE")
+        coded_values = [int(coded_value.text) for coded_value in coded_value_elements]
+        return coded_values
+
+    def create_negative_response(sid, nrc):
+        # sid from request
+        # nrc from dict
+        pass

--- a/src/pykiso/lib/auxiliaries/udsaux/common/uds_callback.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/uds_callback.py
@@ -85,7 +85,9 @@ class UdsCallback:
                 self.request[0] + self.POSITIVE_RESPONSE_OFFSET
             ] + self.request[1:]
 
-        if self.response_data is not None and not isinstance(self.response, dict):
+        if self.response_data is not None and not (
+            isinstance(self.response, dict) or self.response is None
+        ):
             # convert response_data and append it to the response
             self.response_data = (
                 list(self.int_to_bytes(self.response_data))

--- a/src/pykiso/lib/auxiliaries/udsaux/common/uds_callback.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/uds_callback.py
@@ -29,7 +29,7 @@ import time
 import typing
 from dataclasses import dataclass
 from itertools import cycle
-from typing import Callable, ClassVar, List, Optional, Tuple, Union
+from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Union
 
 from uds import IsoServices
 
@@ -60,9 +60,9 @@ class UdsCallback:
     POSITIVE_RESPONSE_OFFSET: ClassVar[int] = 0x40
 
     # e.g. 0x1003 or [0x10, 0x03]
-    request: Union[int, List[int]]
+    request: Union[int, List[int], Dict[str, str]]
     # e.g. 0x5003 or [0x50, 0x03]
-    response: Optional[Union[int, List[int]]] = None
+    response: Optional[Union[int, List[int], Dict[str, str]]] = None
     # e.g. 0x1011 or b'DATA'
     response_data: Optional[Union[int, bytes]] = None
     # specify zero-padding
@@ -79,13 +79,13 @@ class UdsCallback:
 
         if isinstance(self.response, int):
             self.response = list(self.int_to_bytes(self.response))
-        elif self.response is None:
+        elif self.response is None and not isinstance(self.request, dict):
             # create positive response based on request
             self.response = [
                 self.request[0] + self.POSITIVE_RESPONSE_OFFSET
             ] + self.request[1:]
 
-        if self.response_data is not None:
+        if self.response_data is not None and not isinstance(self.response, dict):
             # convert response_data and append it to the response
             self.response_data = (
                 list(self.int_to_bytes(self.response_data))

--- a/src/pykiso/lib/auxiliaries/udsaux/common/uds_callback.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/uds_callback.py
@@ -33,6 +33,8 @@ from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Union
 
 from uds import IsoServices
 
+from pykiso.types import OdxRequestConfigDict
+
 if typing.TYPE_CHECKING:
     from pykiso.lib.auxiliaries.udsaux import UdsServerAuxiliary
 
@@ -60,7 +62,7 @@ class UdsCallback:
     POSITIVE_RESPONSE_OFFSET: ClassVar[int] = 0x40
 
     # e.g. 0x1003 or [0x10, 0x03]
-    request: Union[int, List[int], Dict[str, str]]
+    request: Union[int, List[int], OdxRequestConfigDict]
     # e.g. 0x5003 or [0x50, 0x03]
     response: Optional[Union[int, List[int], Dict[str, str]]] = None
     # e.g. 0x1011 or b'DATA'

--- a/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
@@ -414,11 +414,12 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
             positive response with the specified response_data. Accepts ODX based dictionary
         :return: name of the parameter
         """
+        logging.debug(f"--> req {request}, res= {response}")
         if isinstance(request, dict):
             key = request["data"]["parameter"]
             return key
         else:
-            key, _ = list(response.keys())[0]
+            key = list(response.keys())[0]
             return key
 
     def _abort_command(self) -> None:

--- a/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
@@ -312,7 +312,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         callback_to_execute(received_uds_data, self)
         return
 
-    def _create_uds_data(self, coded_values: List[int]) -> List[int]:
+    def _format_uds_data(self, coded_values: List[int]) -> List[int]:
         """Format a list of coded values into a list of bytes, needed for odx configured callbacks
 
         :param coded_values: coded values of a odx request
@@ -350,7 +350,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
                 request["service"],
                 self.odx_parser.RefType.REQUEST,
             )
-            uds_request = self._create_uds_data(coded_values)
+            uds_request = self._format_uds_data(coded_values)
             if uds_request[0] != request["service"]:
                 log.error(
                     f"Given SID {request['service']} does not match parsed SID {uds_request[0]}"
@@ -376,7 +376,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
                 coded_response_values = self.odx_parser.get_coded_values(
                     key, uds_request[0] + 0x40, self.odx_parser.RefType.POS_RESPONSE
                 )
-                uds_response = self._create_uds_data(coded_response_values)
+                uds_response = self._format_uds_data(coded_response_values)
                 payload = list(data.encode())
                 full_uds_response = uds_response + payload
         else:

--- a/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
@@ -321,7 +321,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         for value in coded_values:
             int_bytes = list(UdsCallback.int_to_bytes(value))
             uds_data.extend(int_bytes)
-        log.debug(f"Created a uds request bytes list from coded values: {uds_data}")
+        log.internal_debug(f"Uds request bytes list from coded values: {uds_data}")
         return uds_data
 
     def _create_callback_from_odx(
@@ -345,28 +345,25 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         :return: UdsCallback with request and response parsed from odx
         """
         log.internal_debug(
-            f"creating odx based callback for request={request}, response={response}"
+            f"Creating odx based callback for request={request}, response={response}"
         )
-        coded_values = self.odx_parser.get_coded_values_by_sd(
-            request["data"]["parameter"]
+        coded_values = self.odx_parser.get_coded_values(
+            request["data"]["parameter"], request["service"]
         )
         uds_request = self._create_uds_data(coded_values)
         if uds_request[0] != request["service"]:
-            log.internal_debug(
-                f"Expected SID {request['service']} does not match parsed SID {uds_request[0]}"
+            log.error(
+                f"Given SID {request['service']} does not match parsed SID {uds_request[0]}"
             )
             raise ValueError(
-                f"Given IsoService {request['service']} does not match parsed SID {uds_request[0]}"
+                f"Given SID {request['service']} does not match parsed SID {uds_request[0]}"
             )
 
         if isinstance(response, dict):
-            # create response from dict -> implementation fro single values TODO: clarify
+            # create response from dict -> implementation for single values
             key, data = response.popitem()
             if key.lower() == "negative" or key == UdsResponse.NEGATIVE_RESPONSE_SID:
                 # create negative response: Negative response SID, request SID, NRC
-                log.internal_debug(
-                    f"Creating a negative response for callback: {UdsResponse.NEGATIVE_RESPONSE_SID},{uds_request[0]}, {data}"
-                )
                 response = [UdsResponse.NEGATIVE_RESPONSE_SID, uds_request[0], data]
             else:
                 # create the response based on the request if its a dict, else it will get autoformatted:

--- a/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright (c) 2010-2022 Robert Bosch GmbH
+# Copyright (c) 2010-2023 Robert Bosch GmbH
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
 # http://www.eclipse.org/legal/epl-2.0.
@@ -363,7 +363,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
 
         if isinstance(response, dict):
             # implementation for single values
-            key, data = response.popitem()
+            key, data = list(response.items())[0]
             if key.lower() == "negative":
                 # create negative response: Negative response SID, request SID, NRC
                 full_uds_response = [

--- a/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/uds_server_auxiliary.py
@@ -217,12 +217,10 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         """
         # handle odx based callbacks
         if isinstance(request, dict):
-            log.internal_debug("----------> CREATE ODX Callback from dict")
             request = self._create_callback_from_odx(
                 request, response, response_data, data_length, callback
             )
         elif isinstance(request, UdsCallback) and isinstance(request.request, dict):
-            log.internal_debug("----------> CREATE ODX Callback from callback")
             request = self._create_callback_from_odx(
                 request.request,
                 request.response,
@@ -321,7 +319,6 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         for value in coded_values:
             int_bytes = list(UdsCallback.int_to_bytes(value))
             uds_data.extend(int_bytes)
-        log.internal_debug(f"Uds request bytes list from coded values: {uds_data}")
         return uds_data
 
     def _create_callback_from_odx(
@@ -344,9 +341,6 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         :param callback: custom callback to register
         :return: UdsCallback with request and response parsed from odx
         """
-        log.internal_debug(
-            f"Creating odx based callback for request={request}, response={response}"
-        )
         coded_values = self.odx_parser.get_coded_values(
             request["data"]["parameter"], request["service"]
         )
@@ -362,7 +356,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         if isinstance(response, dict):
             # create response from dict -> implementation for single values
             key, data = response.popitem()
-            if key.lower() == "negative" or key == UdsResponse.NEGATIVE_RESPONSE_SID:
+            if key.lower() == "negative":
                 # create negative response: Negative response SID, request SID, NRC
                 response = [UdsResponse.NEGATIVE_RESPONSE_SID, uds_request[0], data]
             else:
@@ -373,7 +367,7 @@ class UdsServerAuxiliary(UdsBaseAuxiliary):
         callback = UdsCallback(
             uds_request, response, response_data, data_length, callback
         )
-        log.internal_debug(f"Created a callback from odx: {callback}")
+        log.internal_debug(f"Callback configured from odx: {callback}")
         return callback
 
     def _abort_command(self) -> None:

--- a/src/pykiso/types.py
+++ b/src/pykiso/types.py
@@ -61,3 +61,12 @@ class ConfigDict(TypedDict):
     auxiliaries: Dict[AuxiliaryAlias, AuxiliaryConfig]
     connectors: Dict[ConnectorAlias, ConnectorConfig]
     test_suite_list: List[SuiteConfig]
+
+
+class OdxParamDict(TypedDict):
+    parameter: str
+
+
+class OdxRequestConfigDict(TypedDict):
+    service: int
+    data: OdxParamDict

--- a/tests/test_odx_parser.py
+++ b/tests/test_odx_parser.py
@@ -1,0 +1,251 @@
+##########################################################################
+# Copyright (c) 2010-2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+##########################################################################
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, call
+from xml.etree.ElementTree import Element, ElementTree
+
+import pytest
+
+from pykiso.lib.auxiliaries.udsaux.common.odx_parser import OdxParser
+
+
+def odx_content():
+    odx = """
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ODX MODEL-VERSION="2.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="odx.xsd">
+    <DIAG-LAYER-CONTAINER>
+        <PROTOCOLS>
+            <PROTOCOL ID="1">
+                <SHORT-NAME>CAN_FD</SHORT-NAME>
+                <LONG-NAME>CAN FD</LONG-NAME>
+                <COMPARAM-SPEC-REF ID-REF="ISO_15765_3_on_ISO_15765_2" DOCREF="ISO_15765_3_on_ISO_15765_2" DOCTYPE="COMPARAM-SPEC"/>
+            </PROTOCOL>
+        </PROTOCOLS>
+        <BASE-VARIANTS>
+            <BASE-VARIANT ID="ECUXXX">
+                <SHORT-NAME>ECUxxx</SHORT-NAME>
+                <LONG-NAME>ECUxxx</LONG-NAME>
+                <DIAG-DATA-DICTIONARY-SPEC>
+                    <DATA-OBJECT-PROPS>
+                        <DATA-OBJECT-PROP ID="3">
+                            <SHORT-NAME>Software_Version</SHORT-NAME>
+                            <LONG-NAME>Software_Version</LONG-NAME>
+                            <COMPU-METHOD>
+                                <CATEGORY>IDENTICAL</CATEGORY>
+                            </COMPU-METHOD>
+                            <DIAG-CODED-TYPE BASE-TYPE-ENCODING="ISO-8859-1" BASE-DATA-TYPE="A_ASCIISTRING" xsi:type="STANDARD-LENGTH-TYPE">
+                                <BIT-LENGTH>128</BIT-LENGTH>
+                            </DIAG-CODED-TYPE>
+                            <PHYSICAL-TYPE BASE-DATA-TYPE="A_UNICODE2STRING"/>
+                        </DATA-OBJECT-PROP>
+                    </DATA-OBJECT-PROPS>
+                    <STRUCTURES>
+                        <STRUCTURE>
+                        </STRUCTURE>
+                    </STRUCTURES>
+                </DIAG-DATA-DICTIONARY-SPEC>
+                <DIAG-COMMS>
+                    <DIAG-SERVICE ID="6" SEMANTIC="IDENTIFICATION">
+                        <SHORT-NAME>SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>SoftwareVersion Read</LONG-NAME>
+                        <SDGS>
+                            <SDG>
+                                <SDG-CAPTION ID="7">
+                                    <SHORT-NAME>CANdelaServiceInformation</SHORT-NAME>
+                                </SDG-CAPTION>
+                                <SD SI="DiagInstanceQualifier">SoftwareVersion</SD>
+                                <SD SI="DiagInstanceName">SoftwareVersion</SD>
+                                <SD SI="ServiceQualifier">Read</SD>
+                                <SD SI="ServiceName">Read</SD>
+                                <SD SI="PositiveResponseSuppressed">no</SD>
+                            </SDG>
+                        </SDGS>
+                        <AUDIENCE IS-SUPPLIER="false" IS-DEVELOPMENT="false" IS-MANUFACTURING="false" IS-AFTERSALES="false" IS-AFTERMARKET="false"/>
+                        <REQUEST-REF ID-REF="9"/>
+                        <POS-RESPONSE-REFS>
+                            <POS-RESPONSE-REF ID-REF="10"/>
+                        </POS-RESPONSE-REFS>
+                        <NEG-RESPONSE-REFS>
+                            <NEG-RESPONSE-REF ID-REF="11"/>
+                        </NEG-RESPONSE-REFS>
+                    </DIAG-SERVICE>
+                </DIAG-COMMS>
+                <REQUESTS>
+                    <REQUEST ID="9">
+                        <SHORT-NAME>RQ_SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>RQ SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_RQ</SHORT-NAME>
+                                <LONG-NAME>SID-RQ</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>34</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
+                                <LONG-NAME>Identifier</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>42069</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>16</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                        </PARAMS>
+                    </REQUEST>
+                </REQUESTS>
+                <POS-RESPONSES>
+                    <POS-RESPONSE ID="10">
+                        <SHORT-NAME>PR_SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>PR SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_PR</SHORT-NAME>
+                                <LONG-NAME>SID-PR</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>98</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
+                                <LONG-NAME>Identifier</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>42069</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>16</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="VALUE">
+                                <SHORT-NAME>SoftwareVersion</SHORT-NAME>
+                                <LONG-NAME>SoftwareVersion</LONG-NAME>
+                                <BYTE-POSITION>3</BYTE-POSITION>
+                                <DOP-REF ID-REF="3"/>
+                            </PARAM>
+                        </PARAMS>
+                    </POS-RESPONSE>
+                </POS-RESPONSES>
+                <NEG-RESPONSES>
+                    <NEG-RESPONSE ID="11">
+                        <SHORT-NAME>NR_SoftwareVersion_Read</SHORT-NAME>
+                        <LONG-NAME>NR SoftwareVersion Read</LONG-NAME>
+                        <PARAMS>
+                            <PARAM SEMANTIC="SERVICE-ID" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SID_NR</SHORT-NAME>
+                                <LONG-NAME>SID-NR</LONG-NAME>
+                                <BYTE-POSITION>0</BYTE-POSITION>
+                                <CODED-VALUE>127</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="SERVICEIDRQ" xsi:type="CODED-CONST">
+                                <SHORT-NAME>SIDRQ_NR</SHORT-NAME>
+                                <LONG-NAME>SIDRQ-NR</LONG-NAME>
+                                <BYTE-POSITION>1</BYTE-POSITION>
+                                <CODED-VALUE>34</CODED-VALUE>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="VALUE">
+                                <SHORT-NAME>Read</SHORT-NAME>
+                                <LONG-NAME>Read</LONG-NAME>
+                                <BYTE-POSITION>2</BYTE-POSITION>
+                                <DOP-REF ID-REF="13"/>
+                            </PARAM>
+                            <PARAM SEMANTIC="DATA" xsi:type="NRC-CONST">
+                                <SHORT-NAME>NRCConst_Read</SHORT-NAME>
+                                <LONG-NAME>Read</LONG-NAME>
+                                <BYTE-POSITION>2</BYTE-POSITION>
+                                <CODED-VALUES>
+                                    <CODED-VALUE>19</CODED-VALUE>
+                                    <CODED-VALUE>20</CODED-VALUE>
+                                    <CODED-VALUE>34</CODED-VALUE>
+                                    <CODED-VALUE>49</CODED-VALUE>
+                                    <CODED-VALUE>51</CODED-VALUE>
+                                </CODED-VALUES>
+                                <DIAG-CODED-TYPE BASE-DATA-TYPE="A_UINT32" xsi:type="STANDARD-LENGTH-TYPE">
+                                    <BIT-LENGTH>8</BIT-LENGTH>
+                                </DIAG-CODED-TYPE>
+                            </PARAM>
+                        </PARAMS>
+                    </NEG-RESPONSE>
+                </NEG-RESPONSES>
+                <GLOBAL-NEG-RESPONSES>
+                    <GLOBAL-NEG-RESPONSE ID="14">
+                    </GLOBAL-NEG-RESPONSE>
+                </GLOBAL-NEG-RESPONSES>
+            </BASE-VARIANT>
+        </BASE-VARIANTS>
+    </DIAG-LAYER-CONTAINER>
+</ODX>
+    """
+    return odx
+
+
+@pytest.fixture
+def tmp_odx_file(tmp_path):
+    odx_file = tmp_path / "odx_example.odx"
+    xml = odx_content().strip()
+    odx_file.write_text(xml)
+    return odx_file
+
+
+def test_constructor(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+
+    assert isinstance(odx_parser.odx_tree, ElementTree)
+
+
+def test__find_element_by_odx_id(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+    odx_id = "6"
+    element = odx_parser._find_element_by_odx_id(odx_id)
+
+    assert isinstance(element, Element)
+    assert element.attrib["ID"] == odx_id
+
+
+def test__find_element_by_odx_id_not_found(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+    odx_id = "1337"
+    with pytest.raises(ValueError, match=f"No element with id={odx_id} found"):
+        element = odx_parser._find_element_by_odx_id(odx_id)
+
+
+def test__find_diag_service_by_sd(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+    sd_name = "SoftwareVersion"
+    element = odx_parser._find_diag_service_by_sd(sd_name)
+
+    assert isinstance(element, Element)
+    assert element.tag == "DIAG-SERVICE"
+
+
+def test__find_diag_service_by_sd_not_found(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+    sd_name = "HardwareVersion"
+    with pytest.raises(
+        ValueError, match=f"No DIAG-SERVICE has a SD containing {sd_name}"
+    ):
+        element = odx_parser._find_diag_service_by_sd(sd_name)
+
+
+def test_get_coded_values_by_sd(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+    expected_values = [34, 42069]
+    coded_values = odx_parser.get_coded_values_by_sd("SoftwareVersion")
+    assert coded_values == expected_values

--- a/tests/test_odx_parser.py
+++ b/tests/test_odx_parser.py
@@ -229,10 +229,10 @@ def test__find_element_by_odx_id_not_found(tmp_odx_file):
 def test__find_diag_service_by_sd(tmp_odx_file):
     odx_parser = OdxParser(tmp_odx_file)
     sd_name = "SoftwareVersion"
-    element = odx_parser._find_diag_service_by_sd(sd_name)
-
-    assert isinstance(element, Element)
-    assert element.tag == "DIAG-SERVICE"
+    elements = odx_parser._find_diag_services_by_sd(sd_name)
+    for element in elements:
+        assert isinstance(element, Element)
+        assert element.tag == "DIAG-SERVICE"
 
 
 def test__find_diag_service_by_sd_not_found(tmp_odx_file):
@@ -241,11 +241,22 @@ def test__find_diag_service_by_sd_not_found(tmp_odx_file):
     with pytest.raises(
         ValueError, match=f"No DIAG-SERVICE has a SD containing {sd_name}"
     ):
-        element = odx_parser._find_diag_service_by_sd(sd_name)
+        element = odx_parser._find_diag_services_by_sd(sd_name)
 
 
-def test_get_coded_values_by_sd(tmp_odx_file):
+def test_get_coded_values(tmp_odx_file):
     odx_parser = OdxParser(tmp_odx_file)
     expected_values = [34, 42069]
-    coded_values = odx_parser.get_coded_values_by_sd("SoftwareVersion")
+    coded_values = odx_parser.get_coded_values("SoftwareVersion", 34)
     assert coded_values == expected_values
+
+
+def test_get_coded_values_failure(tmp_odx_file):
+    odx_parser = OdxParser(tmp_odx_file)
+    sw_version = "SoftwareVersion"
+    sid = 46
+    with pytest.raises(
+        ValueError,
+        match=f"Could not create request for service={sid} and sd={sw_version}",
+    ):
+        coded_values = odx_parser.get_coded_values(sw_version, sid)

--- a/tests/test_odx_parser.py
+++ b/tests/test_odx_parser.py
@@ -7,9 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ##########################################################################
 
-import logging
-from pathlib import Path
-from unittest.mock import MagicMock, call
+
 from xml.etree.ElementTree import Element, ElementTree
 
 import pytest

--- a/tests/test_uds_callback.py
+++ b/tests/test_uds_callback.py
@@ -79,6 +79,8 @@ class TestUdsCallback:
             ),
             (ODX_REQUEST, None, b"\x01", 6, None),
             (ODX_REQUEST, None, None, 6, None),
+            (ODX_REQUEST, [0x40, 0x03, 0x01], None, None, [0x40, 0x03, 0x01]),
+            (ODX_REQUEST, [0x40, 0x03, 0x01], 0x02, None, [0x40, 0x03, 0x01, 0x02]),
         ],
     )
     def test_post_init_dict(self, req, resp, data, data_length, expected_resp):

--- a/tests/test_uds_callback.py
+++ b/tests/test_uds_callback.py
@@ -47,6 +47,7 @@ class TestUdsCallback:
                 6,
                 [0x41, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00],
             ),
+            (0x0102, {"SoftwareVersion": "1"}, None, None, {"SoftwareVersion": "1"}),
         ],
     )
     def test_post_init(self, req, resp, data, data_len, expected_resp):

--- a/tests/test_uds_server_auxiliary.py
+++ b/tests/test_uds_server_auxiliary.py
@@ -52,7 +52,7 @@ class TestUdsServerAuxiliary:
         parser = mocker.patch(
             "pykiso.lib.auxiliaries.udsaux.uds_server_auxiliary.OdxParser"
         )
-        parser().get_coded_values_by_sd = MagicMock(return_value=[34, 42069])
+        parser().get_coded_values = MagicMock(return_value=[34, 42069])
         # logging.debug(f"---PARSER: {parser}: {parser.get_coded_values_by_sd()}")
 
         TestUdsServerAuxiliary.uds_aux_instance_odx = UdsServerAuxiliary(
@@ -242,6 +242,11 @@ class TestUdsServerAuxiliary:
                 {"0x22A455": UdsCallback([0x22, 0xA4, 0x55], [0x62, 0xA4, 0x55])},
                 id="Passed odx keyword dict directly no response given",
             ),
+            pytest.param(
+                (ODX_REQUEST, {"Negative": 17}),
+                {"0x22A455": UdsCallback([0x22, 0xA4, 0x55], [0x7F, 0x22, 0x11])},
+                id="Negative response given",
+            ),
         ],
     )
     def test_register_callback(
@@ -251,7 +256,6 @@ class TestUdsServerAuxiliary:
             uds_server_aux_inst.register_callback(*callback_params)
         else:
             uds_server_aux_inst.register_callback(callback_params)
-        logging.info(f"CBs: {uds_server_aux_inst._callbacks}")
         assert uds_server_aux_inst._callbacks == expected_callback_dict
 
     @pytest.mark.parametrize(
@@ -354,9 +358,7 @@ class TestUdsServerAuxiliary:
 
         assert "Unregistered request received" in caplog.text
 
-    # TODO: PARAMETERIZE
     def test__create_callback_from_odx(self, uds_server_aux_inst):
-        logging.info(f"VALS: {uds_server_aux_inst.odx_parser.get_coded_values_by_sd()}")
         callback = uds_server_aux_inst._create_callback_from_odx(ODX_REQUEST)
         assert callback == UdsCallback([0x22, 0xA4, 0x55], [0x62, 0xA4, 0x55])
 

--- a/tests/test_uds_server_auxiliary.py
+++ b/tests/test_uds_server_auxiliary.py
@@ -52,8 +52,10 @@ class TestUdsServerAuxiliary:
         parser = mocker.patch(
             "pykiso.lib.auxiliaries.udsaux.uds_server_auxiliary.OdxParser"
         )
-        parser().get_coded_values = MagicMock(return_value=[34, 42069])
-        # logging.debug(f"---PARSER: {parser}: {parser.get_coded_values_by_sd()}")
+        # gets called for request and reponse
+        mock_request = [34, 42069]
+        mock_response = [98, 42069]
+        parser().get_coded_values = MagicMock(side_effect=[mock_request, mock_response])
 
         TestUdsServerAuxiliary.uds_aux_instance_odx = UdsServerAuxiliary(
             com=ccpcan_inst,
@@ -216,8 +218,7 @@ class TestUdsServerAuxiliary:
                 {
                     "0x22A455": UdsCallback(
                         [0x22, 0xA4, 0x55],
-                        [0x62, 0xA4, 0x55],
-                        [0x30, 0x2E, 0x31, 0x37, 0x2E, 0x30],
+                        [0x62, 0xA4, 0x55, 0x30, 0x2E, 0x31, 0x37, 0x2E, 0x30],
                     )
                 },
                 id="ODX based UdsCallback instance passed",
@@ -227,12 +228,7 @@ class TestUdsServerAuxiliary:
                 {
                     "0x22A455": UdsCallback(
                         [0x22, 0xA4, 0x55],
-                        [
-                            0x62,
-                            0xA4,
-                            0x55,
-                        ],
-                        [0x30, 0x2E, 0x31, 0x37, 0x2E, 0x30],
+                        [0x62, 0xA4, 0x55, 0x30, 0x2E, 0x31, 0x37, 0x2E, 0x30],
                     )
                 },
                 id="Passed odx keyword dict directly",

--- a/tests/test_uds_server_auxiliary.py
+++ b/tests/test_uds_server_auxiliary.py
@@ -365,6 +365,6 @@ class TestUdsServerAuxiliary:
             ([16, 3], [0x10, 0x03]),
         ],
     )
-    def test__create_uds_data(self, uds_server_aux_inst, coded_values, uds_data):
-        actual = uds_server_aux_inst._create_uds_data(coded_values)
+    def test__format_uds_data(self, uds_server_aux_inst, coded_values, uds_data):
+        actual = uds_server_aux_inst._format_uds_data(coded_values)
         assert uds_data == actual


### PR DESCRIPTION
To make the uds server auxiliary more usable, include ODX configuration for UdsServer via keyword dictionaries.

option to:
- use dictionary to create callback and register the callback
- use dictionary directly with register_callback in uds_server