### PR TITLE
fix: decode received bytes in instrument_control_auxiliary

### DIFF
--- a/docs/whats_new/version_0_21_2.rst
+++ b/docs/whats_new/version_0_21_2.rst
@@ -1,4 +1,4 @@
-Version 0.21.1
+Version 0.21.2
 --------------
 
 Remove redundancy of activate_log configuration parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "0.21.1"
+version = "0.21.2"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"

--- a/src/pykiso/lib/auxiliaries/instrument_control_auxiliary/instrument_control_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/instrument_control_auxiliary/instrument_control_auxiliary.py
@@ -161,7 +161,7 @@ class InstrumentControlAuxiliary(DTAuxiliaryInterface):
         log.internal_debug(f"Sending a read request in {self}")
         return self.handle_read()
 
-    def handle_read(self) -> str:
+    def handle_read(self) -> Optional[str]:
         """Handle read command by calling associated connector
         cc_receive.
 
@@ -169,7 +169,10 @@ class InstrumentControlAuxiliary(DTAuxiliaryInterface):
             string
         """
         response = self.channel.cc_receive()
-        return response.get("msg")
+        response_data = response.get("msg")
+        if isinstance(response_data, bytes):
+            response_data = response_data.decode().strip()
+        return response_data
 
     def query(self, query_command: str) -> Union[bytes, str]:
         """Send a query request to the instrument. Uses the 'query' method of the
@@ -183,7 +186,7 @@ class InstrumentControlAuxiliary(DTAuxiliaryInterface):
         log.internal_debug(f"Sending a query request in {self}) for {query_command}")
         return self.handle_query(query_command)
 
-    def handle_query(self, query_command: str) -> str:
+    def handle_query(self, query_command: str) -> Optional[str]:
         """Send a query request to the instrument. Uses the 'query' method of the
             channel if available, uses 'cc_send' and 'cc_receive' otherwise.
 
@@ -199,7 +202,10 @@ class InstrumentControlAuxiliary(DTAuxiliaryInterface):
             self.channel.cc_send(msg=query_command + self.write_termination)
             time.sleep(0.05)
             response = self.channel.cc_receive()
-            return response.get("msg")
+            response_data = response.get("msg")
+            if isinstance(response_data, bytes):
+                response_data = response_data.decode().strip()
+            return response_data
 
     def _create_auxiliary_instance(self) -> bool:
         """Open the connector.

--- a/src/pykiso/test_setup/dynamic_loader.py
+++ b/src/pykiso/test_setup/dynamic_loader.py
@@ -190,11 +190,13 @@ class ModuleCache:
     def _import(self, name: str) -> Type[Union[AuxiliaryCommon, Connector]]:
         """Import the class registered under the alias <name>."""
         try:
-            import_path = self.locations.get(name, "")
+            import_path = self.locations[name]
             location, _class = import_path.rsplit(":", 1)
+        except KeyError:
+            raise ValueError(f"Could not find {name!r} in provided configuration")
         except ValueError:
             raise ValueError(
-                f"specified type must be 'path:Class' or 'module:Class', got '{import_path}'"
+                f"Specified type for {name!r} must be 'path:Class' or 'module:Class', got {import_path!r}"
             )
         if ".py" in location:
             path_loc = pathlib.Path(location)
@@ -205,7 +207,7 @@ class ModuleCache:
                 log.internal_debug(f"loading {_class} as {name} from {path_loc}")
             else:
                 raise ImportError(
-                    f"no python module found at '{path_loc}'", name=_class
+                    f"no python module found at {path_loc!r}", name=_class
                 )
         else:
             module = importlib.import_module(location)

--- a/tests/test_dynamic_loader.py
+++ b/tests/test_dynamic_loader.py
@@ -40,7 +40,11 @@ def linker(example_module):
         },
         "aux_no_class": {
             "connectors": {"com": "chan1"},
-            "type": str(example_module),
+            "type": "some.module.without.aux_class",
+        },
+        "aux_type_not_found": {
+            "connectors": {"com": "chan1"},
+            "type": "some.unknown.module:SomeClass",
         },
         "aux_no_file": {
             "connectors": {"com": "chan1"},
@@ -128,9 +132,16 @@ def test_import_aux_without_connector_error(linker):
         from pykiso.auxiliaries import aux_no_connector_error
 
 
-def test_bad_type_spec(linker):
-    with pytest.raises(Exception):
+def test_bad_type_format(linker):
+    with pytest.raises(ValueError, match="must be 'path:Class' or 'module:Class'"):
         from pykiso.auxiliaries import aux_no_class
+
+
+def test_type_not_found(linker: DynamicImportLinker):
+    linker._aux_cache.locations.pop("aux_type_not_found")
+
+    with pytest.raises(ValueError, match="Could not find"):
+        from pykiso.auxiliaries import aux_type_not_found
 
 
 def test_module_not_found(linker):

--- a/tests/test_instrument_control_auxiliary.py
+++ b/tests/test_instrument_control_auxiliary.py
@@ -191,21 +191,27 @@ def test_handle_write_missmatch_value(mocker, aux_inst, cchannel_inst):
 
 
 def test_handle_read(aux_inst, cchannel_inst):
+    cchannel_inst._cc_receive.return_value = b"data"
 
-    aux_inst.handle_read()
+    read_data = aux_inst.handle_read()
 
     cchannel_inst._cc_receive.assert_called_with(timeout=0.1)
+    assert read_data == b"data"
 
 
 def test_handle_query(mocker, aux_inst, cchannel_inst):
+    expected_return = b"data"
+    cchannel_inst._cc_receive.return_value = expected_return
     mocker.patch("time.sleep", return_value=None)
     query = "SYST:LOCK:OWN?"
-    aux_inst.handle_query(query)
+
+    query_result = aux_inst.handle_query(query)
 
     cchannel_inst._cc_send.assert_called_with(
         msg=f"{query}{aux_inst.write_termination}",
     )
     cchannel_inst._cc_receive.assert_called_with(timeout=0.1)
+    assert query_result == expected_return.decode().strip()
 
 
 def test_handle_query_with_visa_cc(mocker, aux_inst, cc_visa_inst):

--- a/tests/test_instrument_control_auxiliary.py
+++ b/tests/test_instrument_control_auxiliary.py
@@ -191,17 +191,18 @@ def test_handle_write_missmatch_value(mocker, aux_inst, cchannel_inst):
 
 
 def test_handle_read(aux_inst, cchannel_inst):
-    cchannel_inst._cc_receive.return_value = b"data"
+    expected_return = b"data"
+    cchannel_inst._cc_receive.return_value = {"msg": expected_return}
 
     read_data = aux_inst.handle_read()
 
     cchannel_inst._cc_receive.assert_called_with(timeout=0.1)
-    assert read_data == b"data"
+    assert read_data == expected_return.decode().strip()
 
 
 def test_handle_query(mocker, aux_inst, cchannel_inst):
     expected_return = b"data"
-    cchannel_inst._cc_receive.return_value = expected_return
+    cchannel_inst._cc_receive.return_value = {"msg": expected_return}
     mocker.patch("time.sleep", return_value=None)
     query = "SYST:LOCK:OWN?"
 


### PR DESCRIPTION
- Decode bytes received from cchannel to strings as previously returned
- Specify another error case in dynamic loader to improve error reporting
- Bump version to 0.21.2