### PR TITLE
feat: allow proxy auto start and stop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/PyCQA/isort.git
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--line-length", "79"]

--- a/docs/advanced_usage/advanced_config_file.rst
+++ b/docs/advanced_usage/advanced_config_file.rst
@@ -31,12 +31,12 @@ Real-World Configuration File
 Activation of specific loggers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, every logger that does not belong to the `pykiso` package or that is not an `auxiliary`
-logger will see its level set to WARNING even if you have in the command line `pykiso --log-level DEBUG`.
+By default, every logger that does not belong to the ``pykiso`` package or that is not an ``auxiliary``
+logger will see its level set to WARNING even if you have in the command line ``pykiso --log-level DEBUG``.
 
 This aims to reduce redundant logs from additional modules during the test execution.
-For keeping specific loggers to the set log-level, it is possible to set the `activate_log` parameter in the `auxiliary` config.
-The following example activates the `jlink` logger from the `pylink` package, imported in `cc_rtt_segger.py`:
+For keeping specific loggers to the set log-level, it is possible to set the ``activate_log`` parameter in the ``auxiliary`` config.
+The following example activates the ``jlink`` logger from the ``pylink`` package, imported in ``cc_rtt_segger.py``:
 
 .. code:: yaml
 
@@ -55,25 +55,25 @@ The following example activates the `jlink` logger from the `pylink` package, im
       config: null
       type: pykiso.lib.connectors.cc_rtt_segger:CCRttSegger
 
-Based on this example, by specifying `my_pkg`, all child loggers will also be set to the set log-level.
+Based on this example, by specifying ``my_pkg``, all child loggers will also be set to the set log-level.
 
-.. note:: If e.g. only the logger `my_pkg.module_1` should be set to the level, it should be entered as such.
+.. note:: If e.g. only the logger ``my_pkg.module_1`` should be set to the level, it should be entered as such.
 
 Ability to use environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is possible to replace any value by an environment variable in the YAML files.
-When using environment variables, the following format should be respected: `ENV{my-env-var}`.
-In the following example, an environment variable called `TEST_SUITE_1` contains the path to the test suite 1 directory.
+When using environment variables, the following format should be respected: ``ENV{my-env-var}``.
+In the following example, an environment variable called ``TEST_SUITE_1`` contains the path to the test suite 1 directory.
 
 .. literalinclude:: ../../examples/dummy_env_var.yaml
     :language: yaml
     :lines: 22-25
 
 It is also possible to set a default value in case the environment variable is not found.
-The following format should be used: `ENV{my-env-var=my_default_value}`.
+The following format should be used: ``ENV{my-env-var=my_default_value}``.
 
-In the following example, an environment variable called `TEST_SUITE_2` would contain the path to
+In the following example, an environment variable called ``TEST_SUITE_2`` would contain the path to
 the test_suite_2 directory. If the variable is not set, the default value will be taken instead.
 
 .. literalinclude:: ../../examples/dummy_env_var.yaml
@@ -100,7 +100,7 @@ and **will not be parsed**.
         abs_script_path_unix: /home/usr/script_folder/my_awesome_script.py
 
 .. warning::
-  Relative path or file locations must always start with `./`.
+  Relative path or file locations must always start with ``./``.
   If not, it will still be resolved but unexpected behaviour can result from it.
 
 .. _config_sub_yaml:
@@ -127,8 +127,12 @@ All threaded auxiliaries are capable to delay their start-up (not starting at im
 This means, from user point of view, it's possible to start it on demand and especially where
 it's really needed.
 
-.. warning:: in a proxy set-up be sure to always start the proxy auxiliary last
-    otherwise an error will occurred due to proxy auxiliary specific import rules
+.. warning:: in an explicitely defined proxy setup (for shared communication channels) be sure to
+    always start the proxy auxiliary last. Otherwise, an error will occur due to the specific
+    :py:class:`~pykiso.lib.auxiliaries.proxy_auxiliary.ProxyAuxiliary` import rules.
+
+    To avoid such corner cases, consider switching to an
+    :ref:`implicit definition of shared communication channels <sharing_a_cchan>`.
 
 In order to achieved that, a parameter was added at the auxiliary configuration level.
 
@@ -139,8 +143,8 @@ In order to achieved that, a parameter was added at the auxiliary configuration 
       connectors:
           com: can_channel
       config:
-        aux_list : [aux1, aux2]
-        activate_trace : True
+        aux_list: [aux1, aux2]
+        activate_trace: True
         trace_dir: ./suite_proxy
         trace_name: can_trace
         # if False create the auxiliary instance but don't start it, an
@@ -151,13 +155,13 @@ In order to achieved that, a parameter was added at the auxiliary configuration 
       type: pykiso.lib.auxiliaries.proxy_auxiliary:ProxyAuxiliary
     aux1:
       connectors:
-          com: proxy_com1
+        com: proxy_com1
       config:
         auto_start: False
       type: pykiso.lib.auxiliaries.communication_auxiliary:CommunicationAuxiliary
     aux2:
       connectors:
-          com: proxy_com2
+        com: proxy_com2
       config:
         auto_start: False
       type: pykiso.lib.auxiliaries.communication_auxiliary:CommunicationAuxiliary
@@ -346,10 +350,11 @@ Make a proxy auxiliary trace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Proxy auxiliary is capable of creating a trace file, where all received messages at connector
-level are written. This feature is useful when proxy auxiliary is associated with a connector
-who doesn't have any trace capability (in contrast to cc_pcan_can or cc_rtt_segger for example).
+level are written. This feature is useful when proxy auxiliary is associated with a communication channel
+that doesn't have any tracing capability (in contrast to :py:class:`~pykiso.lib.connectors.cc_pcan_can.CCPcanCan`
+or :py:class:`~pykiso.lib.connectors.cc_rtt_segger.CCRttSegger` for example).
 
-Everything is handled at configuration level and especially at yaml file :
+Everything is handled at configuration level within the YAML test configuration file:
 
 .. code:: yaml
 
@@ -372,3 +377,6 @@ Everything is handled at configuration level and especially at yaml file :
       # otherwise user should specify his own name
       trace_name: can_trace
     type: pykiso.lib.auxiliaries.proxy_auxiliary:ProxyAuxiliary
+
+
+.. note:: This feature is only available with an explicit proxy definition as shown :ref:`above <delayed_startup>`.

--- a/docs/modules_usage/uds_auxiliary.rst
+++ b/docs/modules_usage/uds_auxiliary.rst
@@ -101,7 +101,6 @@ refer to the positivity of the response, and its NRC if negative.
 
 Here is an example:
 
-
 .. code:: python
 
     import pykiso
@@ -249,6 +248,7 @@ The methods take as only mandatory argument the received response.
 The parameter rest is the response as a userlist object.
 
 .. code:: python
+
     #Check raw response is positive
     uds_aux.check_raw_response_positive(resp)
 

--- a/docs/whats_new/index.rst
+++ b/docs/whats_new/index.rst
@@ -1,10 +1,10 @@
-What’s New In Pykiso?
+What's New In Pykiso?
 =====================
 
 .. toctree::
 
     version_ongoing
-    version_0_21_1
+    version_0_21_2
     version_0_20_0
     version_0_19_3
     version_0_18_0

--- a/docs/whats_new/version_0_19_3.rst
+++ b/docs/whats_new/version_0_19_3.rst
@@ -37,8 +37,7 @@ It is now possible to select test classes or even test cases with a unix filenam
 pattern.
 This pattern can be passed with the -p flag or inside the yaml file.
 
-For more info see
-:ref:`test_case_patterns`
+For more info see :ref:`test_case_patterns`
 
 
 Agnostic tag call
@@ -83,7 +82,7 @@ Communication Auxiliary
 To save on memory, the communication auxiliary does not collect received messages automatically anymore.
 The functionality is now available with the context manager ``collect_messages``.
 
-See :ref:`examples/templates/suite_com/test_com.py`
+See ``kiso-testing/examples/templates/suite_com/test_com.py``.
 
 The collected messages by the Communication auxiliary can still be cleared with the API method
 :py:meth`~pykiso.lib.auxiliaries.communication_auxiliary.CommunicationAuxiliary.clear_buffer`
@@ -105,7 +104,7 @@ Lightweight UDS auxiliary configuration
 The add of an .ini file to configured the UDS auxiliary and it variant (server)
 is no more mandatory, every parameter is now reachable in the .yaml file.
 
-See :ref:`examples/uds.yaml`
+See ``kiso-testing/examples/uds.yaml``.
 
 In addition, if the tp_layer and uds_layer parameters are not given at yaml level
 a default configuration is applied.

--- a/docs/whats_new/version_ongoing.rst
+++ b/docs/whats_new/version_ongoing.rst
@@ -21,4 +21,4 @@ will remain closed.
 Afterwards, the shared communication channel can be opened and closed by respectively
 starting one of the auxiliaries and stopping all of the auxiliaries.
 
-For more information, please refer to :ref:`sharing_a_cchan`_.
+For more information, please refer to :ref:`sharing_a_cchan`.

--- a/docs/whats_new/version_ongoing.rst
+++ b/docs/whats_new/version_ongoing.rst
@@ -7,3 +7,18 @@ Improved logging for multiple yaml
 It is now possible to use a separate log file for each YAML if multiple are
 provided. A folder can also be passed in which case separate log files will
 be created with the corresponding YAML name.
+
+Entirely hidden Proxy Auxiliary
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There is now no need at all anymore to manually define a ``ProxyAuxiliary`` and
+``CCProxy``s.
+
+If ``auto_start`` is disabled for all auxiliaries sharing a communication channel,
+then the ``ProxyAuxiliary`` won't be started and the shared communication channel
+will remain closed.
+
+Afterwards, the shared communication channel can be opened and closed by respectively
+starting one of the auxiliaries and stopping all of the auxiliaries.
+
+For more information, please refer to :ref:`sharing_a_cchan`_.

--- a/src/pykiso/lib/auxiliaries/mp_proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/mp_proxy_auxiliary.py
@@ -100,37 +100,6 @@ class MpProxyAuxiliary(MpAuxiliaryInterface):
         self.aux_list = aux_list
         super().__init__(**kwargs)
 
-    @property
-    def _open_connections(self) -> int:
-        """A counter monitoring the number of attached running auxiliaries.
-
-        .. warning::
-            Do not set this manually as it can easily result in unexpected behaviours.
-
-
-        :getter: returns the number of currently attached and running auxiliaries.
-        :setter: set by ``CCProxy`` instances when being opened or closed.
-            When no open connection remains and the counter falls back to 0,
-            the ``ProxyAuxiliary`` will be stopped and the attached 'physical'
-            communication channel closed.
-            When the first connection is opened and the counter is increased
-            from 0 to 1, the ``ProxyAuxiliary`` will be started and the attached
-            'physical' communication channel opened.
-        """
-        with self.lock:
-            return self._open_count
-
-    @_open_connections.setter
-    def _open_connections(self, value: int):
-        with self.lock:
-            last_connection_closed = value == 0
-            first_connection_opened = value == 1 and self._open_count == 0
-            self._open_count = value
-            if last_connection_closed:
-                self.delete_instance()
-            elif first_connection_opened and not self.is_instance:
-                self.create_instance()
-
     def _init_trace(
         self,
         logger: logging.Logger,

--- a/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
@@ -122,7 +122,9 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
         with self.lock:
             last_connection_closed = value == 0 and self._open_count == 1
             first_connection_opened = value == 1 and self._open_count == 0
-            self._open_count = value
+            # prevent negative values on invalid initialization
+            if value >= 0:
+                self._open_count = value
             if last_connection_closed and self.is_instance:
                 self.delete_instance()
             elif first_connection_opened and not self.is_instance:

--- a/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
@@ -258,10 +258,20 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
         channels.
 
         .. note:: This method use the thread safe method implemented by
-            each proxy channels(attached_tx_callback).
+            each proxy channel (attach_tx_callback).
         """
         for conn in self.proxy_channels:
             conn.attach_tx_callback(self.run_command)
+
+    def _remove_tx_method_from_channels(self) -> None:
+        """Detach public run_command method from all connected proxy
+        channels.
+
+        .. note:: This method use the thread safe method implemented by
+            each proxy channel (detach_tx_callback).
+        """
+        for conn in self.proxy_channels:
+            conn.detach_tx_callback()
 
     @open_connector
     def _create_auxiliary_instance(self) -> bool:
@@ -281,6 +291,7 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
         :return: if channel deletion is successful return True otherwise
             False
         """
+        self._remove_tx_method_from_channels()
         log.internal_info("Auxiliary instance deleted")
         return True
 

--- a/src/pykiso/lib/connectors/cc_mp_proxy.py
+++ b/src/pykiso/lib/connectors/cc_mp_proxy.py
@@ -41,12 +41,6 @@ log = logging.getLogger(__name__)
 class CCMpProxy(CChannel):
     """Multiprocessing Proxy CChannel for multi auxiliary usage."""
 
-    # keep an uninitialized proxy variable at class-level to fulfill the existence conditions.
-    # when a CCProxy instance will then set it, it will only be set at instance level but stay
-    # uninitialized at class-level
-    _proxy: MpProxyAuxiliary = None
-    _physical_channel: CChannel = None
-
     def __init__(self, **kwargs):
         """Initialize attributes."""
         kwargs.update(processing=True)
@@ -93,18 +87,6 @@ class CCMpProxy(CChannel):
 
     def __setstate__(self, state):
         self.__dict__ = state
-
-    def open(self) -> None:
-        super().open()
-        if self._proxy is not None:
-            # will start the proxy_auxiliary if this is the first CCMpProxy to be opened
-            self._proxy._open_connections += 1
-
-    def close(self) -> None:
-        super().close()
-        if self._proxy is not None:
-            # will stop the proxy_auxiliary if this is the last CCMpProxy to be closed
-            self._proxy._open_connections -= 1
 
     def _cc_open(self) -> None:
         """Open proxy channel.

--- a/src/pykiso/lib/connectors/cc_mp_proxy.py
+++ b/src/pykiso/lib/connectors/cc_mp_proxy.py
@@ -41,6 +41,12 @@ log = logging.getLogger(__name__)
 class CCMpProxy(CChannel):
     """Multiprocessing Proxy CChannel for multi auxiliary usage."""
 
+    # keep an uninitialized proxy variable at class-level to fulfill the existence conditions.
+    # when a CCProxy instance will then set it, it will only be set at instance level but stay
+    # uninitialized at class-level
+    _proxy: MpProxyAuxiliary = None
+    _physical_channel: CChannel = None
+
     def __init__(self, **kwargs):
         """Initialize attributes."""
         kwargs.update(processing=True)

--- a/src/pykiso/lib/connectors/cc_pcan_can.py
+++ b/src/pykiso/lib/connectors/cc_pcan_can.py
@@ -121,8 +121,8 @@ class CCPCanCan(CChannel):
         :param remote_id: id used for transmission
         :param can_filters: iterable used to filter can id on reception
         :param logging_activated: boolean used to disable logfile creation
-        :param bus_error_warning_filter : if True filter the logging message
-        ('Bus error: an error counter')
+        :param bus_error_warning_filter: if True filter the PCAN driver warnings
+            'Bus error: an error counter' from the logs.
         """
         super().__init__(**kwargs)
         self.interface = interface

--- a/src/pykiso/lib/connectors/cc_proxy.py
+++ b/src/pykiso/lib/connectors/cc_proxy.py
@@ -102,10 +102,28 @@ class CCProxy(CChannel):
                 )
             self._tx_callback = func
 
+    def open(self) -> None:
+        super().open()
+        if self._proxy is not None:
+            # this will start the proxy_auxiliary if this is the first CCProxy to be opened
+            self._proxy._open_connections += 1
+
+    def close(self) -> None:
+        super().close()
+        if self._proxy is not None:
+            # this will stop the proxy_auxiliary if this is the last CCProxy to be closed
+            self._proxy._open_connections -= 1
+
     def _cc_open(self) -> None:
         """Open proxy channel."""
         log.internal_info("Open proxy channel")
         self.queue_out = queue.Queue()
+        # will call conn.attach_tx_callback which will try to re-acquire the lock -> deadlock
+        # if self._proxy is not None:
+        #     self._proxy.open_connections += 1
+        # this will too
+        #     if not self._proxy.is_instance:
+        #         self._proxy.create_instance()
 
     def _cc_close(self) -> None:
         """Close proxy channel."""

--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -145,10 +145,15 @@ class ConfigRegistry:
                 mp_enabled = channel_cfg.get("processing", False)
 
             # automatically start proxy if at least one auxiliary has the auto_start flag set
-            auto_start = any(
-                config["auxiliaries"][auxiliary].get("config", {}).get("auto_start")
-                for auxiliary in auxiliaries
-            )
+            for auxiliary in auxiliaries:
+                try:
+                    auto_start = config["auxiliaries"][auxiliary]["config"][
+                        "auto_start"
+                    ]
+                except KeyError:
+                    # default value for auto_start is True
+                    auto_start = True
+                    break
 
             # create a proxy auxiliary config for this shared channel
             proxy_aux_name, proxy_aux_cfg = cls._make_proxy_aux_config(

--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type
 
+from ..exceptions import PykisoError
 from .dynamic_loader import DynamicImportLinker
 
 if TYPE_CHECKING:
@@ -190,7 +191,12 @@ class ConfigRegistry:
 
         # 5. Finally, import required ProxyAuxiliary instances so that user doesn't have to
         for proxy_aux in proxies:
-            cls._linker._aux_cache.get_instance(proxy_aux)
+            try:
+                cls.get_aux_by_alias(proxy_aux)
+            except PykisoError:
+                # ensure that the created ProxyAuxiliary is stopped if its creation fails
+                cls.delete_aux_con()
+                raise
 
     @classmethod
     def delete_aux_con(cls) -> None:

--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -76,6 +76,7 @@ class ConfigRegistry:
         channel_name: ConnectorAlias,
         aux_list: List[AuxiliaryAlias],
         multiprocessing: bool,
+        auto_start: bool,
     ) -> Tuple[AuxiliaryAlias, AuxiliaryConfig]:
         """Craft the configuration dictionary for a proxy auxiliary to be
         attached to all auxiliaries sharing a communication channel.
@@ -94,7 +95,7 @@ class ConfigRegistry:
         name = f"proxy_aux_{channel_name}"
         config = {
             "connectors": {"com": channel_name},
-            "config": {"aux_list": aux_list},
+            "config": {"aux_list": aux_list, "auto_start": auto_start},
             "type": f"{aux_class.__module__}:{aux_class.__name__}",
         }
         return name, config
@@ -134,19 +135,24 @@ class ConfigRegistry:
         # 2. Overwrite auxiliary and connector config with required proxies
         for channel_name, auxiliaries in cchannel_to_auxiliaries.items():
             if len(auxiliaries) < 2:
-                # only one auxiliary holds the channel so there's nothing to patch
+                # only one auxiliary holds the channel so no proxy is required
                 continue
 
             # detect if communication channel is multiprocessing-based
             mp_enabled = False
-            if config["connectors"][channel_name].get("config") is not None:
-                mp_enabled = config["connectors"][channel_name]["config"].get(
-                    "processing", False
-                )
+            channel_cfg = config["connectors"][channel_name].get("config")
+            if channel_cfg is not None:
+                mp_enabled = channel_cfg.get("processing", False)
+
+            # automatically start proxy if at least one auxiliary has the auto_start flag set
+            auto_start = any(
+                config["auxiliaries"][auxiliary].get("config", {}).get("auto_start")
+                for auxiliary in auxiliaries
+            )
 
             # create a proxy auxiliary config for this shared channel
             proxy_aux_name, proxy_aux_cfg = cls._make_proxy_aux_config(
-                channel_name, auxiliaries, mp_enabled
+                channel_name, auxiliaries, mp_enabled, auto_start
             )
             config["auxiliaries"][proxy_aux_name] = proxy_aux_cfg
             proxies.append(proxy_aux_name)

--- a/tests/test_config_registry_and_test_execution.py
+++ b/tests/test_config_registry_and_test_execution.py
@@ -31,7 +31,7 @@ from pykiso.test_setup.config_registry import (
 
 
 @pytest.mark.parametrize("tmp_test", [("aux1", "aux2", False)], indirect=True)
-def test_config_registry_and_test_execution(tmp_test, capsys):
+def test_test_execution(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
 
@@ -53,7 +53,7 @@ def test_config_registry_and_test_execution(tmp_test, capsys):
 
 
 @pytest.mark.parametrize("tmp_test", [("aux1", "aux2", False)], indirect=True)
-def test_config_registry_and_test_execution_with_pattern(tmp_test, capsys):
+def test_test_execution_with_pattern(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
     by specifying a pattern
@@ -72,8 +72,10 @@ def test_config_registry_and_test_execution_with_pattern(tmp_test, capsys):
     assert exit_code == test_execution.ExitCode.ALL_TESTS_SUCCEEDED
 
 
-@pytest.mark.parametrize("tmp_test", [("aux_1", "aux_2", False)], indirect=True)
-def test_config_registry_and_test_execution_with_user_tags(tmp_test, capsys):
+@pytest.mark.parametrize(
+    "tmp_test", [("aux1_badtag", "aux2_badtag", False)], indirect=True
+)
+def test_test_execution_with_bad_user_tags(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
     with an undefined user tag.
@@ -90,8 +92,8 @@ def test_config_registry_and_test_execution_with_user_tags(tmp_test, capsys):
     assert exit_code == test_execution.ExitCode.BAD_CLI_USAGE
 
 
-@pytest.mark.parametrize("tmp_test", [("aux_1", "aux_2", False)], indirect=True)
-def test_config_registry_and_test_execution_with_user_tags(tmp_test, capsys):
+@pytest.mark.parametrize("tmp_test", [("aux1_tags", "aux2_tags", False)], indirect=True)
+def test_test_execution_with_user_tags(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
     with additional user tags.
@@ -136,8 +138,10 @@ def test_parse_test_selection_pattern():
     assert test_file_pattern.test_case == "third"
 
 
-@pytest.mark.parametrize("tmp_test", [("aux1", "aux2", False)], indirect=True)
-def test_config_registry_and_test_execution_collect_error(tmp_test, capsys, mocker):
+@pytest.mark.parametrize(
+    "tmp_test", [("aux1_collect", "aux2_collect", False)], indirect=True
+)
+def test_test_execution_collect_error(tmp_test, capsys, mocker):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
     by specifying a pattern
@@ -208,9 +212,7 @@ def test__check_module_names_invalid(paths, pattern, mocker):
 
 
 @pytest.mark.parametrize("tmp_test", [("aux1", "aux2", False)], indirect=True)
-def test_config_registry_and_test_execution_collect_suites_with_invalid_cli_pattern(
-    tmp_test, mocker
-):
+def test_collect_suites_with_invalid_cli_pattern(tmp_test, mocker):
     """Call collect_test_suites function from test_execution using
     configuration data coming from parse_config method and specifying a invalid
     pattern from cli
@@ -243,9 +245,7 @@ def test_config_registry_and_test_execution_collect_suites_with_invalid_cli_patt
 
 
 @pytest.mark.parametrize("tmp_test", [("aux1", "aux2", False)], indirect=True)
-def test_config_registry_and_test_execution_collect_suites_with_invalid_cfg_pattern(
-    tmp_test, mocker
-):
+def test_collect_suites_with_invalid_cfg_pattern(tmp_test, mocker):
     """Call collect_test_suites function from test_execution using
     configuration data coming from parse_config method and specifying a invalid
     pattern in the cfg
@@ -281,7 +281,7 @@ def test_config_registry_and_test_execution_collect_suites_with_invalid_cfg_patt
     [("collector_error_2_aux1", "collector_error_2_aux", False)],
     indirect=True,
 )
-def test_config_registry_and_test_execution_collect_error_log(mocker, caplog, tmp_test):
+def test_test_execution_collect_error_log(mocker, caplog, tmp_test):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
     by specifying a pattern
@@ -309,9 +309,7 @@ def test_config_registry_and_test_execution_collect_error_log(mocker, caplog, tm
 @pytest.mark.parametrize(
     "tmp_test", [("creation_error_aux1", "creation_error_aux2", False)], indirect=True
 )
-def test_config_registry_and_test_execution_test_auxiliary_creation_error(
-    mocker, caplog, tmp_test
-):
+def test_test_execution_with_auxiliary_creation_error(mocker, caplog, tmp_test):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
     by specifying a pattern
@@ -333,7 +331,7 @@ def test_config_registry_and_test_execution_test_auxiliary_creation_error(
 
 
 @pytest.mark.parametrize("tmp_test", [("text_aux1", "text_aux2", False)], indirect=True)
-def test_config_registry_and_test_execution_with_text_reporting(tmp_test, capsys):
+def test_test_execution_with_text_reporting(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method and
     --text option to show the test results only in console
@@ -361,7 +359,7 @@ def test_config_registry_and_test_execution_with_text_reporting(tmp_test, capsys
     ids=["test failed", "error occurred"],
     indirect=True,
 )
-def test_config_registry_and_test_execution_fail(tmp_test, capsys):
+def test_test_execution_test_failure(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method and
     --text option to show the test results only in console
@@ -385,7 +383,7 @@ def test_config_registry_and_test_execution_fail(tmp_test, capsys):
 @pytest.mark.parametrize(
     "tmp_test", [("juint_aux1", "juint_aux2", False)], indirect=True
 )
-def test_config_registry_and_test_execution_with_junit_reporting(tmp_test, capsys):
+def test_test_execution_with_junit_reporting(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method and
     --junit option to show the test results in console
@@ -408,7 +406,7 @@ def test_config_registry_and_test_execution_with_junit_reporting(tmp_test, capsy
 
 
 @pytest.mark.parametrize("tmp_test", [("step_aux1", "step_aux2", False)], indirect=True)
-def test_config_registry_and_test_execution_with_step_report(tmp_test, capsys):
+def test_test_execution_with_step_report(tmp_test, capsys):
     """Call execute function from test_execution using
     configuration data coming from parse_config method
 
@@ -427,7 +425,7 @@ def test_config_registry_and_test_execution_with_step_report(tmp_test, capsys):
     assert pathlib.Path("step_report.html").is_file()
 
 
-def test_config_registry_and_test_execution_failure_and_error_handling():
+def test_failure_and_error_handling():
     TR_ALL_TESTS_SUCCEEDED = TestResult()
     TR_ONE_OR_MORE_TESTS_FAILED = TestResult()
     TR_ONE_OR_MORE_TESTS_FAILED.failures = [TestCase()]
@@ -604,7 +602,7 @@ def test_apply_variant_filter_multiple_testcases(mocker):
     )
 
 
-def test_test_execution_apply_tc_name_filter(mocker):
+def test_apply_test_case_filter(mocker):
     mock_test_case = mocker.Mock()
     mock_test_case.setUp = None
     mock_test_case.tearDown = None
@@ -648,12 +646,12 @@ def sample_config(mocker: MockerFixture, request: pytest.FixtureRequest):
         "auxiliaries": {
             "aux1": {
                 "connectors": {"com": "channel1"},
-                "config": {"aux_param1": 1},
+                "config": {"aux_param1": 1, "auto_start": False},
                 "type": "some_module:Auxiliary",
             },
             "aux2": {
                 "connectors": {"com": "channel1"},
-                "config": {"aux_param2": 2},
+                "config": {"aux_param2": 2, "auto_start": False},
                 "type": "some_other_module:SomeOtherAuxiliary",
             },
         },
@@ -665,13 +663,22 @@ def sample_config(mocker: MockerFixture, request: pytest.FixtureRequest):
         },
     }
 
-    if getattr(request, "param", None) is True:
+    mp_enable, aux1_auto_start, aux2_auto_start = getattr(
+        request, "param", (False, False, False)
+    )
+
+    if mp_enable:
         config["connectors"]["channel1"]["config"]["processing"] = True
         cc_class = CCMpProxy
         aux_class = MpProxyAuxiliary
     else:
         cc_class = CCProxy
         aux_class = ProxyAuxiliary
+
+    if aux1_auto_start:
+        config["auxiliaries"]["aux1"]["config"]["auto_start"] = True
+    if aux2_auto_start:
+        config["auxiliaries"]["aux2"]["config"]["auto_start"] = True
 
     expected_provide_connector_calls = [
         mocker.call(
@@ -689,18 +696,22 @@ def sample_config(mocker: MockerFixture, request: pytest.FixtureRequest):
             "some_module:Auxiliary",
             aux_cons={"com": "proxy_channel_aux1"},
             aux_param1=1,
+            auto_start=aux1_auto_start,
         ),
         mocker.call(
             "aux2",
             "some_other_module:SomeOtherAuxiliary",
             aux_cons={"com": "proxy_channel_aux2"},
             aux_param2=2,
+            auto_start=aux2_auto_start,
         ),
         mocker.call(
             "proxy_aux_channel1",
             f"{aux_class.__module__}:{aux_class.__name__}",
             aux_cons={"com": "channel1"},
             aux_list=["aux1", "aux2"],
+            # auto_start is expected to be set if any of the attached auxiliaries has it set
+            auto_start=(aux1_auto_start or aux2_auto_start),
         ),
     ]
 
@@ -709,11 +720,21 @@ def sample_config(mocker: MockerFixture, request: pytest.FixtureRequest):
 
 @pytest.mark.parametrize(
     "sample_config",
-    [(True), (False)],
+    [
+        (True, True, True),
+        (False, True, True),
+        (False, False, True),
+        (False, False, False),
+    ],
     indirect=True,
-    ids=["multiprocessing enabled", "multiprocessing_disabled"],
+    ids=[
+        "multiprocessing - auto start",
+        "threading - auto start",
+        "threading - no auto start aux1",
+        "threading - no auto start all auxes",
+    ],
 )
-def test_config_registry_config_patching(mocker: MockerFixture, sample_config):
+def test_config_registry_auto_proxy(mocker: MockerFixture, sample_config):
     mock_linker = mocker.MagicMock()
     mocker.patch(
         "pykiso.test_setup.config_registry.DynamicImportLinker",
@@ -734,7 +755,7 @@ def test_config_registry_config_patching(mocker: MockerFixture, sample_config):
     mock_linker._aux_cache.get_instance.assert_called_once_with("proxy_aux_channel1")
 
 
-def test_config_registry_config_no_patching(mocker: MockerFixture, sample_config):
+def test_config_registry_no_auto_proxy(mocker: MockerFixture, sample_config):
     mock_make_px_channel = mocker.patch.object(
         ConfigRegistry, "_make_proxy_channel_config"
     )


### PR DESCRIPTION
This implements auto start & stop capabilities for the ProxyAuxiliary:
- when the first CCProxy is opened and the ProxyAuxiliary isn't started yet, start it
- when the last CCProxy is closed and the ProxyAuxiliary is running, stop it
- if all auxiliaries are marked with `auto_start: False` in the config, apply this to the created ProxyAuxiliary as well

-> Goal is to entirely hide the proxy from the user as he won't be able to access it anymore in case of an automatic proxy creation