### PR TITLE
fix: fix step report show wrong result

### DIFF
--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -339,7 +339,7 @@ def retry_test_case(
                     elif (
                         getattr(self, "step_report", False) and self.step_report.header
                     ):
-                        step_report.add_retry_information_in_step_report(
+                        step_report.add_retry_information(
                             self, result_test, retry_nb, max_try, e
                         )
 

--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -299,8 +299,9 @@ def retry_test_case(
             current_execution = None
             test_class_name = type(self).__name__
             # Prepare report for the current test so we can get the current result for the class
-            step_report._prepare_report(self, self._testMethodName)
-            result_test = step_report.ALL_STEP_REPORT[test_class_name]["succeed"]
+            if getattr(self, "step_report", False) and self.step_report.header:
+                step_report._prepare_report(self, self._testMethodName)
+                result_test = step_report.ALL_STEP_REPORT[test_class_name]["succeed"]
 
             for retry_nb in range(1, max_try + 1):
                 try:
@@ -336,7 +337,9 @@ def retry_test_case(
                             f">>>>>>>>>> Test {retry_nb}/{max_try} failed <<<<<<<<<<"
                         )
                         raise e
-                    else:
+                    elif (
+                        getattr(self, "step_report", False) and self.step_report.header
+                    ):
                         test_information = step_report.ALL_STEP_REPORT[test_class_name][
                             "test_list"
                         ][self._testMethodName]

--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import traceback
 import unittest
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
@@ -340,24 +339,9 @@ def retry_test_case(
                     elif (
                         getattr(self, "step_report", False) and self.step_report.header
                     ):
-                        test_information = step_report.ALL_STEP_REPORT[test_class_name][
-                            "test_list"
-                        ][self._testMethodName]
-                        # Add information about the number of try
-                        test_information["number_try"] = retry_nb + 1
-                        test_information["max_try"] = max_try
-                        # Add another list to steps to differentiate the try
-                        test_information["steps"].append([])
-                        # We add the error raised if it was not an assertion error
-                        if not isinstance(e, AssertionError):
-                            test_information["unexpected_errors"][-1].append(
-                                traceback.format_exc()
-                            )
-                        test_information["unexpected_errors"].append([])
-                        # Go back to the state before executing the test
-                        step_report.ALL_STEP_REPORT[test_class_name][
-                            "succeed"
-                        ] = result_test
+                        step_report.add_retry_information_in_step_report(
+                            self, result_test, retry_nb, max_try, e
+                        )
 
                     # print counter only after failing test to avoid spamming the console
                     log.info(f">>>>>>>>>> Attempt: {retry_nb +1}/{max_try} <<<<<<<<<<")

--- a/src/pykiso/test_result/assert_step_report.py
+++ b/src/pykiso/test_result/assert_step_report.py
@@ -482,7 +482,7 @@ def generate_step_report(
         report_file.write(output_text)
 
 
-def add_retry_information_in_step_report(
+def add_retry_information(
     test: BasicTest, result_test: bool, retry_nb: int, max_try: int, exc: Exception
 ) -> None:
     """Add information in the step report if a test fails and is retried.

--- a/src/pykiso/test_result/assert_step_report.py
+++ b/src/pykiso/test_result/assert_step_report.py
@@ -219,8 +219,8 @@ def _prepare_report(test: unittest.case.TestCase, test_name: str) -> None:
         test_description = test_method.__doc__ or ""
         ALL_STEP_REPORT[test_class_name]["test_list"][test_name] = {
             "description": test_description,
-            "steps": [],
-            "unexpected_errors": [],
+            "steps": [[]],
+            "unexpected_errors": [[]],
         }
 
 
@@ -234,7 +234,7 @@ def _add_step(
 ):
     global ALL_STEP_REPORT, REPORT_KEYS
 
-    ALL_STEP_REPORT[test_class_name]["test_list"][test_name]["steps"].append(
+    ALL_STEP_REPORT[test_class_name]["test_list"][test_name]["steps"][-1].append(
         dict(zip(REPORT_KEYS, [message, var_name, expected, received, True]))
     )
 
@@ -363,9 +363,9 @@ def assert_decorator(assert_method: types.MethodType):
             log.error(f"Assert step exception: {e}")
             test_case_inst.step_report.last_error_message = f"{e}"
             if parent_method:
-                ALL_STEP_REPORT[test_class_name]["test_list"][test_name][-1][
-                    "succeed"
-                ] = False
+                ALL_STEP_REPORT[test_class_name]["test_list"][test_name]["steps"][-1][
+                    -1
+                ]["succeed"] = False
                 ALL_STEP_REPORT[test_class_name]["succeed"] = False
 
             test_case_inst.step_report.success = False
@@ -396,8 +396,9 @@ def is_test_success(test: dict) -> bool:
     :return: True if each step in a test was successful and no unexpected error
         was raised else False
     """
-    return all([step["succeed"] for step in test["steps"]]) and not test.get(
-        "unexpected_errors"
+    return (
+        all([step["succeed"] for step in test["steps"][-1]])
+        and not test.get("unexpected_errors")[-1]
     )
 
 
@@ -462,9 +463,9 @@ def generate_step_report(
             if test_case in test_result.errors:
                 ALL_STEP_REPORT[class_name]["test_list"][test_method_name][
                     "unexpected_errors"
-                ].append(test_case[1])
-
+                ][-1].append(test_case[1])
                 ALL_STEP_REPORT[class_name]["succeed"] = False
+
     # Render the source template
     render_environment = jinja2.Environment(loader=jinja2.FileSystemLoader(SCRIPT_PATH))
     template = render_environment.get_template(REPORT_TEMPLATE)

--- a/src/pykiso/test_result/assert_step_report.py
+++ b/src/pykiso/test_result/assert_step_report.py
@@ -38,7 +38,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import List, Union
+from typing import Dict, List, Union
 from unittest.case import TestCase, _SubTest
 
 import jinja2
@@ -220,7 +220,10 @@ def _prepare_report(test: unittest.case.TestCase, test_name: str) -> None:
     if not ALL_STEP_REPORT[test_class_name]["test_list"].get(test_name):
         test_method = getattr(test, test_name, None)
         test_description = test_method.__doc__ or ""
-        ALL_STEP_REPORT[test_class_name]["test_list"][test_name] = {
+        ALL_STEP_REPORT[test_class_name]["test_list"][test_name]: Dict[
+            str,
+            Union[str, List[List[Dict[str, Union[str, bool]]]], List[List[str]]],
+        ] = {
             "description": test_description,
             "steps": [[]],
             "unexpected_errors": [[]],

--- a/src/pykiso/test_result/templates/report_template.html.j2
+++ b/src/pykiso/test_result/templates/report_template.html.j2
@@ -39,66 +39,95 @@
             {% for test_name, test_content in class_content["test_list"].items() %}
                 {% set test_success = is_test_success(test_content) -%}
                 <details {% if not test_success %}open class="failed-test-details"{% endif %}><summary><h3>{{test_name}}
-                {% if test_success -%}<span style="color:green;">Success</span>
-                {% else %}<span style="color:red;">Fail</span>
-                {%- endif %}</h3></summary>
+                {% if test_success -%}
+                    <span style="color:green;">Success
+                    {% if test_content.get("number_try") -%}
+                        (attempt: {{test_content.get("number_try")}}/{{test_content.get("max_try")}})
+                    {%- endif %}
+                    </span>
+                {% else %}
+                    <span style="color:red;">Fail
+                    {% if test_content.get("number_try") -%}
+                        ({{test_content.get("number_try")}} attempts made)
+                    {%- endif %}
+                    </span>
+                {%- endif %}
+                </h3></summary>
                 <p>{{test_content["description"] | replace("\n", "<br/>\n") }}</p>
-                <table>
-                    <thead>
-                        <tr>
-                            {# Set Columns name from the first row, excluding succeed flag -#}
-                            <th scope="col" style="width: 3%">Step</th>
-                            {% for column_name in test_content["steps"][0].keys() if column_name != "succeed" -%}
-                                <th scope="col">{{column_name}}</th>
-                            {%- endfor %}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {#- Loop over each assert method called (step-report) -#}
-                        {% for row in test_content["steps"] -%}
-                            {# Set cell color variable according to the assert result and emptiness -#}
-                            {% if row.pop("succeed") -%}
-                                {% set color_cell = "background-color: rgb(196, 243, 196);" -%}
-                                {% set color_empty_cell = "background-color: rgb(250, 250, 128);" -%}
-                            {% else -%}
-                                {% set color_cell = "background-color: rgb(236, 160, 160);" -%}
-                                {% set color_empty_cell = "background-color: rgb(236, 160, 160);" -%}
-                            {%- endif %}
-                            {# Needed for setting unique class per row in html in inner loop -#}
-                            {% set row_index = loop.index -%}
+                {# Loop over the number of try of a test -#}
+                {% for index in range(test_content["steps"] |length) -%}
+                    {# Check if we are in a case of a retry -#}
+                    {% if test_content["steps"] | length >1 and index == 0 -%}
+                       <details><summary><b>Attempt details</b></summary>
+                    {%- endif %}
+                    {% if test_content["steps"] | length >1 -%}
+                        <b>Attempt {{index+1}} :</b>
+                        <br>
+                    {%- endif %}
+                    <table>
+                        <thead>
                             <tr>
-                                <th scope="row" style="{{color_cell}}" >{{loop.index}}</th>
-                                {#- Loop over each cell of the row -#}
-                                {% for col_value in row.values() -%}
-                                    {#- Set the value and apply colors to the cell #}
-                                    <td {% if (col_value or col_value == False) %} style="{{color_cell}}" {% else %} style="{{color_empty_cell}}" {% endif %}>
-                                        {# Use a <details> if content is too long for better results overview and synchronize toggling them per row -#}
-                                        {% if col_value | string | length > 100 -%}
-                                        <details class="{{class_name}}{{test_name}}row_{{row_index}}" ontoggle="toggleDetailsInRow(this, '{{class_name}}{{test_name}}row_{{row_index}}')">
-                                            <summary>{{col_value | string | truncate(53, true, leeway = 0)}}</summary>
-                                            <br>
+                                {% if test_content["steps"][index] | length >0 -%}
+                                    {# Set Columns name from the first row, excluding succeed flag -#}
+                                    <th scope="col" style="width: 3%">Step</th>
+                                    {% for column_name in test_content["steps"][index][0].keys() if column_name != "succeed" -%}
+                                        <th scope="col">{{column_name}}</th>
+                                    {%- endfor %}
+                                {%- endif %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {#- Loop over each assert method called (step-report) -#}
+                            {% for row in test_content["steps"][index] -%}
+                                {# Set cell color variable according to the assert result and emptiness -#}
+                                {% if row.pop("succeed") == true -%}
+                                    {% set color_cell = "background-color: rgb(196, 243, 196);" -%}
+                                    {% set color_empty_cell = "background-color: rgb(250, 250, 128);" -%}
+                                {% else -%}
+                                    {% set color_cell = "background-color: rgb(236, 160, 160);" -%}
+                                    {% set color_empty_cell = "background-color: rgb(236, 160, 160);" -%}
+                                {%- endif %}
+                                {# Needed for setting unique class per row in html in inner loop -#}
+                                {% set row_index = loop.index -%}
+                                <tr>
+                                    <th scope="row" style="{{color_cell}}" >{{loop.index}}</th>
+                                    {#- Loop over each cell of the row -#}
+                                    {% for col_value in row.values() -%}
+                                        {#- Set the value and apply colors to the cell #}
+                                        <td {% if (col_value or col_value == False) %} style="{{color_cell}}" {% else %} style="{{color_empty_cell}}" {% endif %}>
+                                            {# Use a <details> if content is too long for better results overview and synchronize toggling them per row -#}
+                                            {% if col_value | string | length > 100 -%}
+                                            <details class="{{class_name}}{{test_name}}row_{{row_index}}" ontoggle="toggleDetailsInRow(this, '{{class_name}}{{test_name}}row_{{row_index}}')">
+                                                <summary>{{col_value | string | truncate(53, true, leeway = 0)}}</summary>
+                                                <br>
+                                                <div>
+                                                    {{col_value}}
+                                                </div>
+                                            </details>
+                                            {%- else -%}
                                             <div>
                                                 {{col_value}}
                                             </div>
-                                        </details>
-                                        {%- else -%}
-                                        <div>
-                                            {{col_value}}
-                                        </div>
-                                        {%- endif %}
-                                    </td>
-                                {%- endfor %}
-                            </tr>
-                        {%- endfor %}
-                    </tbody>
-                </table>
-                {% if test_content.get("unexpected_errors") -%}
+                                            {%- endif %}
+                                        </td>
+                                    {%- endfor %}
+                                </tr>
+                            {%- endfor %}
+
+                        </tbody>
+                    </table>
+                    {% if test_content["unexpected_errors"][index] -%}
                     <b style='color:red;'><strong>Unexpected errors happened :</strong> <br></b>
-                        {% for error in test_content.get("unexpected_errors") -%}
+                        {% for error in test_content.get("unexpected_errors")[index] -%}
                             <pre>{{error}}</pre>
                         {%- endfor %}
 
-                {%- endif %}
+                    {%- endif %}
+                    {% if (test_content["steps"] | length >1 and (index+2 == (test_content["steps"] | length))) -%}
+                            </details>
+                    {%- endif %}
+                {%- endfor %}
+
                 </details>
             {%- endfor %}
 

--- a/tests/test_assert_step_report.py
+++ b/tests/test_assert_step_report.py
@@ -302,7 +302,7 @@ def test_determine_parent_test_function_with_test_function(function_name):
 
 
 @pytest.mark.parametrize("result_test", (False, True))
-def test_add_retry_information_in_step_report(mocker, result_test):
+def test_add_retry_information(mocker, result_test):
     max_try = 3
     retry_nb = 2
     format_exec_mock = mocker.patch("traceback.format_exc", return_value="error_info")
@@ -322,7 +322,7 @@ def test_add_retry_information_in_step_report(mocker, result_test):
     }
     assert_step_report.ALL_STEP_REPORT = all_step_report_mock
 
-    assert_step_report.add_retry_information_in_step_report(
+    assert_step_report.add_retry_information(
         mock_test_case_class, result_test, retry_nb, max_try, ValueError
     )
 

--- a/tests/test_assert_step_report.py
+++ b/tests/test_assert_step_report.py
@@ -132,7 +132,7 @@ def test_assert_decorator_reraise(mocker, test_case):
     step_result = mocker.patch("pykiso.test_result.assert_step_report._add_step")
     assert_step_report.ALL_STEP_REPORT = OrderedDict()
     assert_step_report.ALL_STEP_REPORT["TestCase"] = {
-        "test_list": {"test_assert_decorator_reraise": [{"succeed": True}]}
+        "test_list": {"test_assert_decorator_reraise": {"steps": [[{"succeed": True}]]}}
     }
 
     data_to_test = False
@@ -142,7 +142,7 @@ def test_assert_decorator_reraise(mocker, test_case):
     assert (
         assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"][
             "test_assert_decorator_reraise"
-        ][-1]["succeed"]
+        ]["steps"][-1][-1]["succeed"]
         == False
     )
     step_result.assert_called_once_with(
@@ -221,7 +221,6 @@ def test_generate(mocker, test_result):
 
 
 def test_add_step():
-
     assert_step_report.ALL_STEP_REPORT["TestCase"] = OrderedDict()
     assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"] = OrderedDict()
     assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"][
@@ -229,7 +228,7 @@ def test_add_step():
     ] = {}
     steplist = assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"][
         "test_assert_step_report_multi_input"
-    ]["steps"] = []
+    ]["steps"] = [[]]
 
     assert_step_report._add_step(
         "TestCase",
@@ -243,12 +242,17 @@ def test_add_step():
 
 
 def test_is_test_success():
-
-    test_ok = {"steps": [{"succeed": True}, {"succeed": True}, {"succeed": True}]}
-    test_fail = {"steps": [{"succeed": True}, {"succeed": False}, {"succeed": True}]}
+    test_ok = {
+        "steps": [[{"succeed": True}, {"succeed": True}, {"succeed": True}]],
+        "unexpected_errors": [[]],
+    }
+    test_fail = {
+        "steps": [[{"succeed": True}, {"succeed": False}, {"succeed": True}]],
+        "unexpected_errors": [[]],
+    }
     test_fail_error = {
-        "steps": [{"succeed": True}, {"succeed": True}, {"succeed": True}],
-        "unexpected_errors": "error",
+        "steps": [[{"succeed": True}, {"succeed": True}, {"succeed": True}]],
+        "unexpected_errors": [["error"]],
     }
 
     assert assert_step_report.is_test_success(test_ok)

--- a/tests/test_test_case.py
+++ b/tests/test_test_case.py
@@ -13,6 +13,7 @@ from functools import partial
 
 import pytest
 
+import pykiso.test_result.assert_step_report as step_report
 from pykiso import cli, retry_test_case
 from pykiso.logging_initializer import LogOptions
 from pykiso.test_coordinator import test_case
@@ -334,6 +335,7 @@ def test_retry_on_failure_decorator(
         ]
     # fix __name__ for the mock.test_run
     mock_test_case_class.test_run.__name__ = "test_run"
+    mock_test_case_class._testMethodName = "test_run"
 
     partial_test_run = partial(
         retry_test_case(max_try, rerun_setup, rerun_teardown, stability_test)(
@@ -350,3 +352,52 @@ def test_retry_on_failure_decorator(
     assert mock_test_case_class.setUp.call_count == expected_setup_count
     assert mock_test_case_class.test_run.call_count == expected_run_count
     assert mock_test_case_class.tearDown.call_count == expected_teardown_count
+
+
+def test_retry_on_failure_decorator_step_report(mocker):
+    max_try = 3
+    format_exec_mock = mocker.patch("traceback.format_exc", return_value="error_info")
+    mock_test_case_class = mocker.Mock()
+    mock_test_case_class.test_run.__name__ = "test_run"
+    mock_test_case_class._testMethodName = "test_run"
+    all_step_report_mock = {
+        type(mock_test_case_class).__name__: {
+            "test_list": {
+                "test_run": {
+                    "steps": [[{"succeed": False}, {"succeed": True}]],
+                    "unexpected_errors": [[]],
+                }
+            },
+            "succeed": True,
+        }
+    }
+    step_report.ALL_STEP_REPORT = all_step_report_mock
+    prepare_report_mock = mocker.patch(
+        "pykiso.test_result.assert_step_report._prepare_report"
+    )
+    mock_test_case_class.test_run.side_effect = [
+        Exception("try again"),
+        Exception("try harder"),
+        "bingo",
+    ]
+
+    partial_test_run = partial(
+        retry_test_case(max_try, False, False, False)(mock_test_case_class.test_run)
+    )
+
+    partial_test_run(mock_test_case_class)
+
+    assert step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__][
+        "test_list"
+    ]["test_run"]["steps"] == [[{"succeed": False}, {"succeed": True}], [], []]
+    assert step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__][
+        "test_list"
+    ]["test_run"]["unexpected_errors"] == [["error_info"], ["error_info"], []]
+    assert (
+        step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__]["test_list"][
+            "test_run"
+        ]["max_try"]
+        == max_try
+    )
+    assert format_exec_mock.call_count == 2
+    prepare_report_mock.assert_called_once_with(mock_test_case_class, "test_run")

--- a/tests/test_test_case.py
+++ b/tests/test_test_case.py
@@ -370,7 +370,7 @@ def test_retry_on_failure_decorator_step_report(mocker):
         "pykiso.test_result.assert_step_report._prepare_report"
     )
     add_retry_mocker = mocker.patch(
-        "pykiso.test_result.assert_step_report.add_retry_information_in_step_report"
+        "pykiso.test_result.assert_step_report.add_retry_information"
     )
     mock_test_case_class.test_run.side_effect = [
         Exception("try again"),


### PR DESCRIPTION
- Fix wrong result in step report
- Assertion for retry test are now separated in different tables for every test and only the last attempt is visible for the user but he can toggle to see all the information of the test.