### PR TITLE
Apply various found fixes and improvements

### DIFF
--- a/src/pykiso/interfaces/dt_auxiliary.py
+++ b/src/pykiso/interfaces/dt_auxiliary.py
@@ -140,6 +140,7 @@ class DTAuxiliaryInterface(abc.ABC):
         with self.lock:
             # if the current aux is alive don't try to create it again
             if self.is_instance:
+                log.internal_info(f"Auxiliary {self.name} is already created")
                 return True
 
             is_created = self._create_auxiliary_instance()
@@ -166,6 +167,7 @@ class DTAuxiliaryInterface(abc.ABC):
             # if the current aux is not alive don't try to delete it
             # again
             if not self.is_instance:
+                log.internal_info(f"Auxiliary {self.name} is already deleted")
                 return True
 
             # stop each auxiliary's tasks
@@ -188,10 +190,9 @@ class DTAuxiliaryInterface(abc.ABC):
             log.internal_debug("transmit task is not needed, don't start it")
             return
 
-        log.internal_debug(f"start transmit task {self.name}_tx")
-        self.tx_thread = threading.Thread(
-            name=f"{self.name}_tx", target=self._transmit_task
-        )
+        task_name = f"{self.name}_tx"
+        log.internal_debug("start transmit task %s", task_name)
+        self.tx_thread = threading.Thread(name=task_name, target=self._transmit_task)
         self.tx_thread.start()
 
     def _start_rx_task(self) -> None:
@@ -200,16 +201,15 @@ class DTAuxiliaryInterface(abc.ABC):
             log.internal_debug("reception task is not needed, don't start it")
             return
 
-        log.internal_debug(f"start reception task {self.name}_rx")
-        self.rx_thread = threading.Thread(
-            name=f"{self.name}_rx", target=self._reception_task
-        )
+        task_name = f"{self.name}_rx"
+        log.internal_debug("start reception task %s", task_name)
+        self.rx_thread = threading.Thread(name=task_name, target=self._reception_task)
         self.rx_thread.start()
 
     def _stop_tx_task(self) -> None:
         """Stop transmission task."""
         if self.tx_task_on is False:
-            log.internal_debug("transmit task was not started, so no need to stop it")
+            log.internal_debug("transmit task was not started, no need to stop it")
             return
 
         log.internal_debug(f"stop transmit task {self.name}_tx")
@@ -221,7 +221,7 @@ class DTAuxiliaryInterface(abc.ABC):
     def _stop_rx_task(self) -> None:
         """Stop reception task."""
         if self.rx_task_on is False:
-            log.internal_debug("recpetion task was not started, so no need t stop it")
+            log.internal_debug("reception task was not started, no need to stop it")
             return
 
         log.internal_debug(f"stop reception task {self.name}_rx")

--- a/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
@@ -125,10 +125,12 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
             # prevent negative values on invalid initialization
             if value >= 0:
                 self._open_count = value
-            if last_connection_closed and self.is_instance:
-                self.delete_instance()
-            elif first_connection_opened and not self.is_instance:
-                self.create_instance()
+        # stop proxy if the last attached auxiliary was stopped
+        if last_connection_closed and self.is_instance:
+            self.delete_instance()
+        # start proxy if the first attached auxiliary is started
+        elif first_connection_opened and not self.is_instance:
+            self.create_instance()
 
     @staticmethod
     def _init_trace(

--- a/src/pykiso/lib/connectors/cc_pcan_can.py
+++ b/src/pykiso/lib/connectors/cc_pcan_can.py
@@ -373,7 +373,9 @@ class CCPCanCan(CChannel):
             else:
                 return {"msg": None}
         except can.CanError as can_error:
-            log.internal_debug(f"encountered can error: {can_error}")
+            log.internal_info(
+                f"encountered CAN error while receiving message: {can_error}"
+            )
             return {"msg": None}
         except Exception:
             log.exception(f"encountered error while receiving message via {self}")

--- a/src/pykiso/lib/connectors/cc_proxy.py
+++ b/src/pykiso/lib/connectors/cc_proxy.py
@@ -126,7 +126,7 @@ class CCProxy(CChannel):
     def _cc_close(self) -> None:
         """Close proxy channel."""
         log.internal_debug("Close proxy channel")
-        self.queue_out = queue.Queue()
+        self.queue_out = None
 
     def _cc_send(self, *args: Any, **kwargs: Any) -> None:
         """Call the attached ProxyAuxiliary's transmission callback

--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -116,9 +116,19 @@ def initialize_logging(
     # add internal kiso log levels
     add_internal_log_levels()
 
-    # update logging options
-    global log_options
-    log_options = LogOptions(log_path, log_level, report_type, verbose)
+    class InternalLogsFilter(logging.Filter):
+        def filter(self, record):
+            """Filters internal log levels
+
+            :param record: event being logged
+
+            :return: False if internal logging, True otherwise
+            """
+            return record.levelno not in (
+                logging.INTERNAL_WARNING,
+                logging.INTERNAL_INFO,
+                logging.INTERNAL_DEBUG,
+            )
 
     # if log_path is given create a file handler
     if log_path is not None:
@@ -131,6 +141,10 @@ def initialize_logging(
         file_handler.setFormatter(log_format)
         file_handler.setLevel(LEVELS[log_level])
         root_logger.addHandler(file_handler)
+
+    # update logging options after having modified the log path
+    global log_options
+    log_options = LogOptions(log_path, log_level, report_type, verbose)
 
     # if report_type is junit use sys.stdout as stream
     if report_type == "junit":

--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -44,7 +44,7 @@ class LogOptions(NamedTuple):
     Namedtuple containing the available options for logging configuration.
     """
 
-    log_path: PathType
+    log_path: Optional[PathType]
     log_level: str
     report_type: str
     verbose: bool
@@ -89,7 +89,7 @@ def add_internal_log_levels() -> None:
 
 
 def initialize_logging(
-    log_path: PathType,
+    log_path: Optional[PathType],
     log_level: str,
     verbose: bool,
     report_type: str = None,

--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -19,7 +19,6 @@ Integration Test Framework
 
 """
 import importlib
-import json
 import logging
 import re
 import sys
@@ -27,7 +26,7 @@ import time
 from ast import literal_eval
 from functools import partialmethod
 from pathlib import Path
-from typing import Any, List, NamedTuple, Optional, Union
+from typing import List, NamedTuple, Optional, Union
 
 from .test_setup.dynamic_loader import PACKAGE
 from .types import PathType
@@ -115,20 +114,6 @@ def initialize_logging(
     )
     # add internal kiso log levels
     add_internal_log_levels()
-
-    class InternalLogsFilter(logging.Filter):
-        def filter(self, record):
-            """Filters internal log levels
-
-            :param record: event being logged
-
-            :return: False if internal logging, True otherwise
-            """
-            return record.levelno not in (
-                logging.INTERNAL_WARNING,
-                logging.INTERNAL_INFO,
-                logging.INTERNAL_DEBUG,
-            )
 
     # if log_path is given create a file handler
     if log_path is not None:

--- a/tests/test_cc_pcan_can.py
+++ b/tests/test_cc_pcan_can.py
@@ -716,7 +716,9 @@ def test_can_recv_can_error_exception(caplog, mocker, mock_can_bus, mock_PCANBas
 
     assert response["msg"] is None
     assert response.get("remote_id") is None
-    assert "encountered can error: Invalid Message" in caplog.text
+    assert (
+        "encountered CAN error while receiving message: Invalid Message" in caplog.text
+    )
 
 
 def test_merge_trc(trc_files, mock_can_bus, mock_PCANBasic):

--- a/tests/test_logging_initializer.py
+++ b/tests/test_logging_initializer.py
@@ -9,7 +9,7 @@
 
 import logging
 import sys
-from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
@@ -17,14 +17,16 @@ from pykiso import logging_initializer
 
 
 @pytest.mark.parametrize(
-    "path, level, expected_level, verbose, report_type",
+    "path, level, expected_level, expected_path_type verbose, report_type",
     [
-        (None, "INFO", logging.INFO, False, "junit"),
-        ("test/test", "WARNING", logging.WARNING, True, "text"),
-        (None, "ERROR", logging.ERROR, False, None),
+        (None, "INFO", logging.INFO, type(None), False, "junit"),
+        ("test/test", "WARNING", logging.WARNING, Path, True, "text"),
+        (None, "ERROR", logging.ERROR, type(None), False, None),
     ],
 )
-def test_initialize_logging(mocker, path, level, expected_level, verbose, report_type):
+def test_initialize_logging(
+    mocker, path, level, expected_level, expected_path_type, verbose, report_type
+):
     mocker.patch("logging.Logger.addHandler")
     mocker.patch("logging.FileHandler.__init__", return_value=None)
     mkdir_mock = mocker.patch("pathlib.Path.mkdir")
@@ -46,7 +48,7 @@ def test_initialize_logging(mocker, path, level, expected_level, verbose, report
         assert logging_initializer.log_options.verbose == True
     assert isinstance(logger, logging.Logger)
     assert logger.isEnabledFor(expected_level)
-    assert logging_initializer.log_options.log_path == path
+    assert isinstance(logging_initializer.log_options.log_path, expected_path_type)
     assert logging_initializer.log_options.log_level == level
     assert logging_initializer.log_options.report_type == report_type
 

--- a/tests/test_logging_initializer.py
+++ b/tests/test_logging_initializer.py
@@ -17,7 +17,7 @@ from pykiso import logging_initializer
 
 
 @pytest.mark.parametrize(
-    "path, level, expected_level, expected_path_type verbose, report_type",
+    "path, level, expected_level, expected_path_type, verbose, report_type",
     [
         (None, "INFO", logging.INFO, type(None), False, "junit"),
         ("test/test", "WARNING", logging.WARNING, Path, True, "text"),


### PR DESCRIPTION
Some inconsistencies were found and this PR tackles them:
- CCPcanCan log the error with info level instead of debug in case of a CanError
- CCProxy set the queue to None when closed to avoid overflowing it when not needed
- Logging update log_options after manipulating the used log_path
- DTAuxiliaryInterface log when an auxiliary is already started/stopped