### PR TITLE
Bugfix/proxy auto start

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ testpaths = [
 addopts = """\
     --verbose \
     --log-level=INFO \
+    -p no:pytest_kiso \
     --cov=./src \
     --cov-report=html \
     --cov-report html:./tests/coverage_report.html \

--- a/src/pykiso/interfaces/dt_auxiliary.py
+++ b/src/pykiso/interfaces/dt_auxiliary.py
@@ -387,8 +387,9 @@ def close_connector(func: Callable) -> Callable:
         """
         log.internal_info("Close channel")
         try:
+            ret = func(self, *arg, **kwargs)
             self.channel.close()
-            return func(self, *arg, **kwargs)
+            return ret
         except Exception:
             log.exception("Unable to close channel communication")
             return False

--- a/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
@@ -49,6 +49,7 @@ auxiliaries. This auxiliary is only usable through proxy connector.
 """
 
 import logging
+import queue
 import sys
 import time
 from pathlib import Path
@@ -96,6 +97,19 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
         self.logger = self._init_trace(activate_trace, trace_dir, trace_name)
         self.proxy_channels = self.get_proxy_con(aux_list)
 
+    def _count_open_proxy_channels(self) -> int:
+        """
+        Get the number of proxy channels connected to this auxiliary
+        that are currently open.
+        """
+        return len(
+            [
+                ccproxy
+                for ccproxy in self.proxy_channels
+                if isinstance(ccproxy.queue_out, queue.Queue)
+            ]
+        )
+
     @property
     def _open_connections(self) -> int:
         """A counter monitoring the number of attached running auxiliaries.
@@ -120,11 +134,19 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
     def _open_connections(self, value: int):
         # locking shouldn't be necessary but we're never too paranoid
         with self.lock:
+            # on the original proxy setup, the auxiliaries are created before the proxy
+            # therefore, when the first auxiliary will be stopped, the counter value will be -1
+            if value < 0:
+                value = self._count_open_proxy_channels()
             last_connection_closed = value == 0 and self._open_count == 1
             first_connection_opened = value == 1 and self._open_count == 0
+<<<<<<< HEAD
             # prevent negative values on invalid initialization
             if value >= 0:
                 self._open_count = value
+=======
+            self._open_count = value
+>>>>>>> ff79fc5 (fix: handle proxy autostart when being instanciated after auxiliaries and close channel at last)
         # stop proxy if the last attached auxiliary was stopped
         if last_connection_closed and self.is_instance:
             self.delete_instance()

--- a/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
@@ -140,13 +140,7 @@ class ProxyAuxiliary(DTAuxiliaryInterface):
                 value = self._count_open_proxy_channels()
             last_connection_closed = value == 0 and self._open_count == 1
             first_connection_opened = value == 1 and self._open_count == 0
-<<<<<<< HEAD
-            # prevent negative values on invalid initialization
-            if value >= 0:
-                self._open_count = value
-=======
             self._open_count = value
->>>>>>> ff79fc5 (fix: handle proxy autostart when being instanciated after auxiliaries and close channel at last)
         # stop proxy if the last attached auxiliary was stopped
         if last_connection_closed and self.is_instance:
             self.delete_instance()

--- a/src/pykiso/lib/connectors/cc_pcan_can.py
+++ b/src/pykiso/lib/connectors/cc_pcan_can.py
@@ -21,6 +21,7 @@ Can Communication Channel using PCAN hardware
 
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -400,7 +401,10 @@ class CCPCanCan(CChannel):
             else:
                 # Else write the first trace content in the log file and then remove it
                 result_trace = Path(self.trace_path / self.trace_name)
-                list_of_traces[0] = list_of_traces[0].rename(result_trace)
+                list_of_traces[0] = shutil.move(
+                    str(list_of_traces[0]), str(result_trace)
+                )
+                list_of_traces[0] = Path(list_of_traces[0])
 
             # End of the trace header
             first_message_line = 33


### PR DESCRIPTION
This PR tackles the auto start of a proxy auxiliary even when the attached auxiliaries are pre-loaded (`import aux1, aux2, proxy_aux`)

It also changes the close_connector decorator to close the channel at the very end, otherwise errors occur in the tx_thread when closing the proxy

See result:
```
INTERNAL_INFO pykiso.interfaces.dt_auxiliary:dt_auxiliary.py:163 Deleting instance of auxiliary aux1
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:127 Before value=-1 self._open_count=0
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:135 After value=3 self._open_count=3 first_connection_opened=False last_connection_closed=False
INTERNAL_INFO pykiso.interfaces.dt_auxiliary:dt_auxiliary.py:163 Deleting instance of auxiliary aux2
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:127 Before value=2 self._open_count=3
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:135 After value=2 self._open_count=2 first_connection_opened=False last_connection_closed=False
INTERNAL_INFO pykiso.interfaces.dt_auxiliary:dt_auxiliary.py:163 Deleting instance of auxiliary aux3
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:127 Before value=1 self._open_count=2
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:135 After value=1 self._open_count=1 first_connection_opened=False last_connection_closed=False
INTERNAL_INFO pykiso.interfaces.dt_auxiliary:dt_auxiliary.py:163 Deleting instance of auxiliary aux4
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:127 Before value=0 self._open_count=1
INFO     pykiso.lib.auxiliaries.proxy_auxiliary:proxy_auxiliary.py:135 After value=0 self._open_count=0 first_connection_opened=False last_connection_closed=True
```