### PR TITLE
fix: add junitxml option to default pytest options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ addopts = """\
     --verbose \
     --log-level=INFO \
     -p no:pytest_kiso \
+    --junitxml=reports/testReport.xml \
     --cov=./src \
     --cov-report=html \
     --cov-report html:./tests/coverage_report.html \


### PR DESCRIPTION
Addresses https://github.com/eclipse/kiso-testing/issues/313

-> junit report is complete again: https://ci.eclipse.org/kiso-testing/job/kiso-testing/job/PR-321/1/testReport/