### PR TITLE
fix: re-enable active loggers and add context manager for ConfigRegistry

### DIFF
--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -214,6 +214,9 @@ def main(
             f"Mismatch: {len(log_path)} log files were provided for {len(test_configuration_file)} yaml configuration files"
         )
 
+    # parse provided tags (any unknown option)
+    user_tags = eval_user_tags(click_context)
+
     if logger:
         change_logger_class(log_level, verbose, logger)
 
@@ -235,7 +238,6 @@ def main(
 
         # Run tests
         with ConfigRegistry.provide_auxiliaries(cfg_dict):
-            user_tags = eval_user_tags(click_context)
             exit_code = test_execution.execute(
                 cfg_dict,
                 report_type,

--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -22,7 +22,7 @@ import logging
 import pprint
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import click
 

--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -22,7 +22,7 @@ import logging
 import pprint
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
 
@@ -208,44 +208,44 @@ def main(
     :param verbose: activate logging for the whole framework
     :param logger: class of the logger that will be used in the tests
     """
+    # we are expecting one log file path or as many as the provided configuration files
+    if log_path and len(log_path) not in (1, len(test_configuration_file)):
+        raise click.UsageError(
+            f"Mismatch: {len(log_path)} log files were provided for {len(test_configuration_file)} yaml configuration files"
+        )
+
     if logger:
         change_logger_class(log_level, verbose, logger)
 
     for idx, config_file in enumerate(test_configuration_file):
         yaml_name = Path(config_file).stem
-        # Set the logging
+
+        # Setup the logging
         if log_path:
-            # Put all logs in one file
-            if len(log_path) == 1:
-                log = initialize_logging(
-                    log_path[0], log_level, verbose, report_type, yaml_name
-                )
-            # Log in different files for each yaml
-            elif len(log_path) == len(test_configuration_file):
-                log = initialize_logging(
-                    log_path[idx], log_level, verbose, report_type, yaml_name
-                )
-            else:
-                raise click.UsageError(
-                    f"Mismatch: {len(test_configuration_file)} yaml config files provided but {len(log_path)} log files"
-                )
+            # Put all logs in one file if only one file is provided, otherwise use a new file for each yaml
+            log_file = log_path[0] if len(log_path) == 1 else log_path[idx]
         else:
-            log_path = None
-            log = initialize_logging(log_path, log_level, verbose, report_type)
+            log_file = None
+
+        log = initialize_logging(log_file, log_level, verbose, report_type, yaml_name)
+
         # Get YAML configuration
-
         cfg_dict = parse_config(config_file)
+        log.debug("cfg_dict:\n%s", pprint.pprint(cfg_dict))
+
         # Run tests
-        log.debug("cfg_dict:\n{}".format(pprint.pformat(cfg_dict)))
+        with ConfigRegistry.provide_auxiliaries(cfg_dict):
+            user_tags = eval_user_tags(click_context)
+            exit_code = test_execution.execute(
+                cfg_dict,
+                report_type,
+                yaml_name,
+                user_tags,
+                step_report,
+                pattern,
+                failfast,
+            )
 
-        ConfigRegistry.register_aux_con(cfg_dict)
-
-        user_tags = eval_user_tags(click_context)
-
-        exit_code = test_execution.execute(
-            cfg_dict, report_type, yaml_name, user_tags, step_report, pattern, failfast
-        )
-        ConfigRegistry.delete_aux_con()
         for handler in logging.getLogger().handlers:
             if isinstance(handler, logging.FileHandler):
                 logging.getLogger().removeHandler(handler)

--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -205,6 +205,9 @@ def add_logging_level(level_name: str, level_num: int):
 def initialize_loggers(loggers: Optional[List[str]]) -> None:
     """Deactivate all external loggers except the specified ones.
 
+    Store the loggers that should remain active globally to keep them
+    activated when this function is called multiple times.
+
     :param loggers: list of logger names to keep activated
     """
     global active_loggers
@@ -240,6 +243,10 @@ def initialize_loggers(loggers: Optional[List[str]]) -> None:
     loggers_to_deactivate = set(relevant_loggers) - set(active_loggers)
     for logger_name in loggers_to_deactivate:
         logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+    # but keep the other ones to the configured level as they could have deactivated by a previous call
+    for logger_name in active_loggers:
+        logging.getLogger(logger_name).setLevel(log_options.log_level)
 
 
 def import_object(path: str) -> Union[None, logging.Logger]:

--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -21,7 +21,8 @@ Config Registry
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Dict, Iterator, List, Tuple, Type
 
 from ..exceptions import PykisoError
 from .dynamic_loader import DynamicImportLinker
@@ -205,6 +206,23 @@ class ConfigRegistry:
         """
         cls._linker.uninstall()
         cls._linker = None
+
+    @contextmanager
+    @classmethod
+    def provide_auxiliaries(cls, config: ConfigDict) -> Iterator[None]:
+        """Context manager that registers importable auxiliary
+        aliases and cleans them up at exit.
+
+        :param config: config dictionary from the YAML configuration
+            file.
+
+        :yield: None
+        """
+        try:
+            cls.register_aux_con(config)
+            yield
+        finally:
+            cls.delete_aux_con()
 
     @classmethod
     def get_all_auxes(cls) -> Dict[AuxiliaryAlias, AuxiliaryCommon]:

--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Dict, Iterator, List, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Tuple, Type
 
 from ..exceptions import PykisoError
 from .dynamic_loader import DynamicImportLinker
@@ -260,7 +260,7 @@ class ConfigRegistry:
         return cls._linker._aux_cache.get_instance(alias)
 
     @classmethod
-    def get_aux_config(cls, name: AuxiliaryAlias) -> AuxiliaryConfig:
+    def get_aux_config(cls, name: AuxiliaryAlias) -> Dict[str, Any]:
         """Return the registered auxiliary configuration based on his
         name.
 

--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -207,8 +207,8 @@ class ConfigRegistry:
         cls._linker.uninstall()
         cls._linker = None
 
-    @contextmanager
     @classmethod
+    @contextmanager
     def provide_auxiliaries(cls, config: ConfigDict) -> Iterator[None]:
         """Context manager that registers importable auxiliary
         aliases and cleans them up at exit.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,7 +319,7 @@ def tmp_test(request, tmp_path, mocker):
         return_value=log_options,
     )
 
-    aux1, aux2, should_fail = request.param
+    aux1, aux2, should_fail = getattr(request, "param", ("dummy1", "dummy2", False))
     ts_folder = tmp_base / f"test_suite_{aux1}_{aux2}"
     ts_folder.mkdir(parents=True)
     tc_file = ts_folder / f"test_{aux1}_{aux2}.py"

--- a/tests/test_config_registry_and_test_execution.py
+++ b/tests/test_config_registry_and_test_execution.py
@@ -116,6 +116,19 @@ def test_test_execution_with_user_tags(tmp_test, capsys):
     assert exit_code == test_execution.ExitCode.ALL_TESTS_SUCCEEDED
 
 
+def test_config_registry_context_manager(tmp_test, mocker):
+    mock_register_aux_con = mocker.patch.object(ConfigRegistry, "register_aux_con")
+    mocker_delete_aux_con = mocker.patch.object(ConfigRegistry, "delete_aux_con")
+
+    cfg = parse_config(tmp_test)
+
+    with ConfigRegistry.provide_auxiliaries(cfg):
+        pass
+
+    mock_register_aux_con.assert_called_once_with(cfg)
+    mocker_delete_aux_con.assert_called_once_with()
+
+
 def test_parse_test_selection_pattern():
     test_file_pattern = ()
     test_file_pattern = test_execution.parse_test_selection_pattern("first::")

--- a/tests/test_logging_initializer.py
+++ b/tests/test_logging_initializer.py
@@ -64,6 +64,11 @@ def test_get_logging_options():
     assert options.log_level == "ERROR"
     assert options.report_type is None
 
+    # restore log level, otherwise the caplog fixture is misconfigured
+    logging_initializer.log_options = logging_initializer.LogOptions(
+        None, "DEBUG", None, False
+    )
+
 
 def test_deactivate_all_loggers(caplog):
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
- flatten log path assignment in cli.py
- add a context manager to ConfigRegistry to ensure proper cleanup
- re-enable previously deactivate loggers in initialize_loggers