### PR TITLE
Bugfix/disable run command when auxiliary is stopped

### DIFF
--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -48,6 +48,18 @@ class AuxiliaryCreationError(PykisoError):
         super().__init__(self.message)
 
 
+class AuxiliaryNotStarted(PykisoError):
+    """Raised when an auxiliary instance creation failed."""
+
+    def __init__(self, aux_name: str) -> None:
+        """Initialize attributes.
+
+        :param aux_name: configured auxiliary alias.
+        """
+        self.message = f"Auxiliary {aux_name} was not started, cannot run command"
+        super().__init__(self.message)
+
+
 class ConnectorRequiredError(PykisoError):
     """Raised when an auxiliary instance creation failed because a connector is
     required and none is provided

--- a/src/pykiso/exceptions.py
+++ b/src/pykiso/exceptions.py
@@ -49,7 +49,10 @@ class AuxiliaryCreationError(PykisoError):
 
 
 class AuxiliaryNotStarted(PykisoError):
-    """Raised when an auxiliary instance creation failed."""
+    """
+    Raised when an action that requires an auxiliary to be running
+    is executed although the auxiliary is stopped.
+    """
 
     def __init__(self, aux_name: str) -> None:
         """Initialize attributes.

--- a/src/pykiso/interfaces/dt_auxiliary.py
+++ b/src/pykiso/interfaces/dt_auxiliary.py
@@ -77,7 +77,7 @@ class DTAuxiliaryInterface(abc.ABC):
         self.name = name
         self.is_proxy_capable = is_proxy_capable
         self.auto_start = auto_start
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         self.stop_tx = threading.Event()
         self.stop_rx = threading.Event()
         self.queue_in = queue.Queue()
@@ -221,8 +221,6 @@ class DTAuxiliaryInterface(abc.ABC):
             return
 
         log.internal_debug(f"stop transmit task {self.name}_tx")
-        for _ in range(self.queue_in.qsize()):
-            self.queue_in.get_nowait()
         self.queue_in.put((AuxCommand.DELETE_AUXILIARY, None))
         self.stop_tx.set()
         self.tx_thread.join()


### PR DESCRIPTION
- Raise an AuxiliaryNotStarted error if the user wants to execute a command while the auxiliary is stopped (otherwise it messes up the input queue of the auxiliary)
- Add the `timeout_result` keyword argument to `run_command` to be able to specify a command's return value in case of a timeout (for flexibility and future refactorings)