### PR TITLE
refactor: set internal log levels lower than non internal ones

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ testpaths = [
 ]
 addopts = """\
     --verbose \
-    --log-level=INFO \
+    --log-level=DEBUG \
     -p no:pytest_kiso \
     --junitxml=reports/testReport.xml \
     --cov=./src \

--- a/src/pykiso/lib/connectors/cc_rtt_segger.py
+++ b/src/pykiso/lib/connectors/cc_rtt_segger.py
@@ -343,7 +343,7 @@ class CCRttSegger(connector.CChannel):
                 self.rtt_log_buffer_idx, self.rtt_log_buffer_size
             )
             if log_msg:
-                self.rtt_log.internal_debug(bytes(log_msg).decode())
+                self.rtt_log.debug(bytes(log_msg).decode())
             time.sleep(self.rtt_log_refresh_time)  # reduce resource consumption
 
     @_need_connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,11 @@ from pykiso.lib.auxiliaries import dut_auxiliary
 from pykiso.lib.connectors import cc_example
 from pykiso.lib.connectors.cc_pcan_can import CCPCanCan
 from pykiso.lib.connectors.cc_vector_can import CCVectorCan
-from pykiso.logging_initializer import LogOptions, get_logging_options
+from pykiso.logging_initializer import (
+    LogOptions,
+    get_logging_options,
+    initialize_logging,
+)
 from pykiso.test_coordinator import test_case
 from pykiso.test_coordinator.test_case import define_test_parameters
 from pykiso.test_setup.dynamic_loader import DynamicImportLinker

--- a/tests/test_auxiliary.py
+++ b/tests/test_auxiliary.py
@@ -71,7 +71,7 @@ def mock_mp_aux(mocker):
     class MockMpAux(MpAuxiliaryInterface):
         def __init__(self, param_1=None, param_2=None, **kwargs):
             logging_initializer.log_options = logging_initializer.LogOptions(
-                None, "ERROR", None, False
+                None, "DEBUG", None, False
             )
             self.param_1 = param_1
             self.param_2 = param_2

--- a/tests/test_cc_fdx_lauterbach.py
+++ b/tests/test_cc_fdx_lauterbach.py
@@ -306,7 +306,7 @@ def test_cc_close(mocker, caplog):
     lauterbach_inst.t32_api = mock_t32_api
     mock_load_script = mocker.patch.object(lauterbach_inst, "load_script")
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         cc_closed = lauterbach_inst._cc_close()
 
     assert (

--- a/tests/test_cc_pcan_can.py
+++ b/tests/test_cc_pcan_can.py
@@ -333,7 +333,7 @@ def test_constructor(constructor_params, expected_config, caplog, mocker):
     param = constructor_params.values()
     log = logging.getLogger("can.pcan")
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         can_inst = CCPCanCan(*param)
     log.warning("Bus error: an error counter")
     can_inst.trace_path = ""
@@ -420,7 +420,7 @@ def test_macos_instantiation(mock_can_bus, mock_PCANBasic, mocker, caplog):
     # Instantiation to test
     connector = CCPCanCan(logging_activated=True)
     # Run the action to test
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         connector._cc_open()
     # Validation of the warning popped
     assert "TRACE_FILE_SEGMENTED deactivated for macos!" in [
@@ -725,7 +725,7 @@ def test_can_recv_can_error_exception(caplog, mocker, mock_can_bus, mock_PCANBas
 
     logging.getLogger("pykiso.lib.connectors.cc_pcan_can.log")
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
 
         with CCPCanCan() as can:
             response = can._cc_receive(timeout=0.0001)
@@ -815,7 +815,7 @@ def test_read_trace_messages(mocker, trc_files, caplog):
 
     mocker.patch.object(CCPCanCan, "_remove_offset", side_effect=["msg1", "msg2"])
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         result = cc_pcan._read_trace_messages(trc_files, trc_files[0])
 
     result_trace = trc_files[0]

--- a/tests/test_cc_rtt_segger.py
+++ b/tests/test_cc_rtt_segger.py
@@ -186,9 +186,7 @@ def test_rtt_segger_cc_open_rtt_error(
     mocker_thread_start = mocker.patch(
         "pykiso.lib.connectors.cc_rtt_segger.threading.Thread.start"
     )
-    with caplog.at_level(
-        logging.INFO,
-    ):
+    with caplog.at_level(logging.INTERNAL_INFO):
         cc_rtt_inst = CCRttSegger(
             rtt_log_path=tmpdir, connection_timeout=0, rtt_log_buffer_idx=5
         )
@@ -285,9 +283,7 @@ def test_rtt_segger_send_error(mock_pylink_square_socket, mocker, caplog):
 
     with CCRttSegger() as cc_rtt_inst:
         mocker.patch.object(cc_rtt_inst.jlink, "rtt_write", side_effect=Exception)
-        with caplog.at_level(
-            logging.ERROR,
-        ):
+        with caplog.at_level(logging.ERROR):
             cc_rtt_inst._cc_send(msg=[0])
         assert (
             f"ERROR occurred while sending {len([0])} bytes on buffer {cc_rtt_inst.tx_buffer_idx}"
@@ -410,7 +406,7 @@ def test_receive_log(
 
     mocker_sleep.assert_called_once_with(expected_sleep)
     if log_return:
-        mock_rtt_log.internal_debug.assert_called_once_with("rtt_log")
+        mock_rtt_log.debug.assert_called_once_with("rtt_log")
 
 
 def test_reset_jlink(mocker):

--- a/tests/test_cc_serial.py
+++ b/tests/test_cc_serial.py
@@ -81,7 +81,7 @@ def test_constructor_auto_port_warn(caplog, mocker):
     with mock.patch.object(
         serial.tools.list_ports, "comports", return_value=[test_device, test_device2]
     ):
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INTERNAL_WARNING):
             cc_serial = CCSerial(port=None, pid=1, vid=2)
     assert (
         "Found multiple devices, ['test_device', 'test_device2'], with matching IDs 0002:0001 or serial_number None. Select first device test_device."

--- a/tests/test_cc_socket_can.py
+++ b/tests/test_cc_socket_can.py
@@ -122,7 +122,7 @@ def test_import():
 def test_constructor(constructor_params, expected_config, caplog):
     param = constructor_params.values()
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         can_inst = CCSocketCan(*param)
 
     assert can_inst.channel == expected_config["channel"]

--- a/tests/test_cc_udp.py
+++ b/tests/test_cc_udp.py
@@ -130,9 +130,7 @@ def test_udp_recv_invalid(mocker, mock_udp_socket, expected_exception, caplog):
     mocker.patch("socket.socket.recvfrom", side_effect=expected_exception)
 
     with CCUdp("120.0.0.7", 5005) as udp_inst:
-        with caplog.at_level(
-            logging.DEBUG,
-        ):
+        with caplog.at_level(logging.INTERNAL_DEBUG):
             msg_received = udp_inst._cc_receive(timeout=0.0000001)
         assert (
             f"encountered error while receiving message via {udp_inst}" in caplog.text

--- a/tests/test_cc_udp_server.py
+++ b/tests/test_cc_udp_server.py
@@ -168,9 +168,7 @@ def test_udp_recv_invalid(mocker, mock_udp_socket, side_effect_mock, caplog):
     mocker.patch("socket.socket.recvfrom", side_effect=side_effect_mock)
 
     with CCUdpServer("120.0.0.7", 5005) as udp_server:
-        with caplog.at_level(
-            logging.DEBUG,
-        ):
+        with caplog.at_level(logging.INTERNAL_DEBUG):
             msg_received = udp_server._cc_receive(timeout=0.0000001)
         assert (
             f"encountered error while receiving message via {udp_server}" in caplog.text

--- a/tests/test_cc_vector_can.py
+++ b/tests/test_cc_vector_can.py
@@ -129,7 +129,7 @@ def test_import():
 def test_constructor(constructor_params, expected_config, caplog):
     param = constructor_params.values()
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         can_inst = CCVectorCan(*param)
 
     assert can_inst.bustype == expected_config["bustype"]

--- a/tests/test_cc_visa.py
+++ b/tests/test_cc_visa.py
@@ -162,7 +162,7 @@ def test__process_request(mocker, constructor_params_serial, scpi_cmds, caplog):
         request="query", request_data=scpi_cmds["trigger_other_error"]
     ) == {"msg": ""}
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         assert visa_inst._process_request(
             request="Test", request_data=scpi_cmds["trigger_other_error"]
         ) == {"msg": ""}

--- a/tests/test_com_aux.py
+++ b/tests/test_com_aux.py
@@ -60,7 +60,7 @@ def test_com_aux_messaging(com_aux_linker, caplog):
 
     with com_aux.collect_messages():
         assert com_aux.send_message(msg)
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.INTERNAL_DEBUG):
             rec_msg = com_aux.receive_message()
 
     assert rec_msg == msg

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -289,7 +289,7 @@ def test_parse_config(tmp_cfg, tmp_path, mocker, caplog):
     )
     mock_check_req = mocker.patch("pykiso.config_parser.check_requirements")
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         cfg = parse_config(tmp_cfg)
 
     mock_check_req.assert_called_once_with([{"pykiso": ">=0.0.0"}])
@@ -428,7 +428,7 @@ def test_parse_config_folder_conflict(tmp_cfg_folder_conflict, tmp_path, caplog)
     # without enforcing ./ notation or putting the value in single quotes
     old_cwd = Path.cwd()
     os.chdir(tmp_path)
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         cfg = parse_config(tmp_cfg_folder_conflict)
 
     # key should not be parsed if it matches a folder/file
@@ -565,7 +565,7 @@ def test_check_requirements(
     mocker.patch("pkg_resources.get_distribution", new=get_version)
     mock_exit = mocker.patch("sys.exit")
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         check_requirements(requirements)
 
     if exit_reason:
@@ -578,7 +578,7 @@ def test_check_requirements(
 def test_check_requirements_package(caplog, mocker):
     mock_exit = mocker.patch("sys.exit")
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         check_requirements([{"not_installed_package": "1.2.3"}])
 
     mock_exit.assert_called_once_with(1)

--- a/tests/test_connector_interface.py
+++ b/tests/test_connector_interface.py
@@ -91,7 +91,7 @@ def test_channel_cc_send(channel_obj):
 def test_channel_cc_send_raw(channel_obj, caplog):
     cc_inst = channel_obj(name="thread-channel")
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         cc_inst.cc_send(msg=b"\x01\x02\x03", raw=True)
     assert (
         "Use of 'raw' keyword argument is deprecated. It won't be passed to '_cc_send'."
@@ -111,7 +111,7 @@ def test_channel_cc_receive(channel_obj):
 def test_channel_cc_receive_raw(channel_obj, caplog):
     cc_inst = channel_obj(name="thread-channel")
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         cc_inst.cc_receive(raw=True)
     assert (
         "Use of 'raw' keyword argument is deprecated. It won't be passed to '_cc_receive'."

--- a/tests/test_flash_lauterbach.py
+++ b/tests/test_flash_lauterbach.py
@@ -144,7 +144,7 @@ def test_open(
     caplog, lauterbach_flasher, mock_psutil, mock_subprocess, mock_remote_api
 ):
     lauterbach_flasher.loadup_wait_time = 0
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         lauterbach_flasher.open()
         assert (
             "Trace32 process open with arguments ['fake_path', '-c', 'fake_config_file']"
@@ -191,7 +191,7 @@ def test_close(
     lauterbach_flasher.loadup_wait_time = 0
     lauterbach_flasher.open()
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         lauterbach_flasher.close()
 
     assert "Disconnect from Trace32 with state 0" in caplog.text
@@ -222,7 +222,7 @@ def test_flash(
     mocker.patch.object(ctypes, "c_int", return_value=CtypeTypeMock(0))
     mocker.patch("time.sleep", return_value=None)
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         lauterbach_flasher.flash()
 
     assert "flash procedure successful" in caplog.text

--- a/tests/test_logging_initializer.py
+++ b/tests/test_logging_initializer.py
@@ -66,7 +66,7 @@ def test_get_logging_options():
 
 
 def test_deactivate_all_loggers(caplog):
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         logging_initializer.initialize_loggers(["all"])
 
     assert "All loggers are activated" in caplog.text
@@ -103,16 +103,6 @@ def test_import_object_error(mocker):
 
     import_module_mock.assert_called_once_with("test.path")
     get_attr_mock.assert_called_once_with("module", "object")
-
-
-def test_add_filter_to_handler():
-    TestLogger.__init__ = logging_initializer.add_filter_to_handler(TestLogger.__init__)
-
-    log = TestLogger("test")
-
-    assert isinstance(
-        log.handlers[0].filters[0], logging_initializer.InternalLogsFilter
-    )
 
 
 def test_remove_handler_from_logger():

--- a/tests/test_mp_proxy_auxiliary.py
+++ b/tests/test_mp_proxy_auxiliary.py
@@ -197,7 +197,7 @@ def test_get_proxy_con_pre_load(mocker, mp_proxy_auxiliary_inst, caplog):
 
     ConfigRegistry._linker = Linker()
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         result_get_proxy = mp_proxy_auxiliary_inst.get_proxy_con(["later_aux"])
 
     assert (
@@ -319,7 +319,7 @@ def test_getattr_physical_cchannel(
 
 def test_create_auxiliary_instance(mp_proxy_auxiliary_inst, caplog):
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         result_create_inst = mp_proxy_auxiliary_inst._create_auxiliary_instance()
     assert result_create_inst is True
     assert "Create auxiliary instance" in caplog.text
@@ -340,7 +340,7 @@ def test_delete_auxiliary_instance(
     mock_empty_queue = mocker.patch.object(MpProxyAuxiliary, "_empty_queue")
     mp_proxy_auxiliary_inst.proxy_channels = [mock_auxiliaries[1], mock_auxiliaries[2]]
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
 
         result = mp_proxy_auxiliary_inst._delete_auxiliary_instance()
     assert "Delete auxiliary instance" in caplog.text
@@ -364,7 +364,7 @@ def test_receive_message(mp_proxy_auxiliary_inst, mock_auxiliaries, caplog):
         "remote_id": "Test_source",
     }
     mp_proxy_auxiliary_inst.proxy_channels = [proxy_channel_test]
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         result_rec_message = mp_proxy_auxiliary_inst._receive_message(1)
     assert (
         f"raw data : {b'340'.hex()} || channel : {mp_proxy_auxiliary_inst.channel.name}"

--- a/tests/test_record_auxiliary.py
+++ b/tests/test_record_auxiliary.py
@@ -101,7 +101,7 @@ def test_instance_active_error_thread_start(caplog, mocker, mock_channel):
 
     record_aux = RecordAuxiliary(mock_channel, is_active=False)
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         record_aux._create_auxiliary_instance()
 
     assert "Error encountered during channel creation" in caplog.text
@@ -112,7 +112,7 @@ def test_delete_aux_error(caplog, mocker, mock_channel):
     mocker.patch.object(threading.Thread, "start")
     record_aux = RecordAuxiliary(mock_channel, is_active=False)
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         record_aux._delete_auxiliary_instance()
     assert "Unable to close Channel." in caplog.text
 
@@ -173,7 +173,7 @@ def test_receive_open_error(caplog, mocker, mock_channel):
 
     record_aux = RecordAuxiliary(mock_channel, is_active=False)
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         record_aux.receive()
     assert "Error encountered while channel creation." in caplog.text
 
@@ -188,7 +188,7 @@ def test_receive_close_error(caplog, mocker, mock_channel):
     record_aux.stop_receive_event = mock_event
     mocker.patch.object(record_aux, "set_data", side_effect="Received data: test")
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         record_aux.receive()
     assert "Error encountered while closing channel." in caplog.text
 
@@ -297,7 +297,7 @@ def test_wait_message_in_log_failed(mocker, caplog, exception_on_failure, mock_c
                 timeout=0.1,
             )
     else:
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INTERNAL_WARNING):
             record_aux.wait_for_message_in_log(
                 message="test", timeout=0.1, exception_on_failure=False
             )
@@ -429,7 +429,7 @@ def test_dumping_failed_path_log_empty(mocker, caplog, mock_channel):
     record_aux = RecordAuxiliary(mock_channel, is_active=True)
     record_aux.set_data("Received data :")
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         result = record_aux.dump_to_file(filename="test.log")
 
     assert "Log data is empty. skip dump to file." in caplog.text
@@ -467,6 +467,6 @@ def test_stop_recording(mocker, caplog, mock_channel):
     )
     record_aux = RecordAuxiliary(mock_channel, is_active=True)
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         record_aux.stop_recording()
         assert f"{record_aux.name} Recording has stopped" in caplog.text

--- a/tests/test_simple_auxiliary.py
+++ b/tests/test_simple_auxiliary.py
@@ -82,7 +82,7 @@ def test_resume(mocker, aux_instance):
 def test_resume_error(caplog, aux_instance):
     aux_instance.is_instance = True
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         aux_instance.resume()
 
     assert "is already running" in caplog.text
@@ -103,7 +103,7 @@ def test_suspend(mocker, aux_instance):
 def test_suspend_error(caplog, aux_instance):
     aux_instance.is_instance = False
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INTERNAL_WARNING):
         aux_instance.suspend()
 
     assert "is already stopped" in caplog.text

--- a/tests/test_simulated_auxiliary.py
+++ b/tests/test_simulated_auxiliary.py
@@ -153,9 +153,7 @@ def mock_msg(mocker):
 def test_constructor(mocker, caplog):
     mocker.patch.object(simulation.Simulation, "__init__", return_value=None)
 
-    with caplog.at_level(
-        logging.DEBUG,
-    ):
+    with caplog.at_level(logging.INTERNAL_DEBUG):
         simulated_aux = simulated_auxiliary.SimulatedAuxiliary(
             name="test_aux",
         )
@@ -171,10 +169,9 @@ def test_create_auxiliary_instance(mocker, simulated_constructor_init, caplog):
 
     mocker.patch.object(simulated_aux, "channel")
 
-    with caplog.at_level(
-        logging.INFO,
-    ):
+    with caplog.at_level(logging.INTERNAL_INFO):
         result_create_inst = simulated_aux._create_auxiliary_instance()
+
     assert result_create_inst is True
     assert "Create auxiliary instance" in caplog.text
     assert "Enable channel" in caplog.text
@@ -183,10 +180,10 @@ def test_create_auxiliary_instance(mocker, simulated_constructor_init, caplog):
 def test_delete_auxiliary_instance(mocker, simulated_constructor_init, caplog):
     simulated_aux = simulated_constructor_init
     mock_channel_close = mocker.patch.object(simulated_aux.channel, "close")
-    with caplog.at_level(
-        logging.INFO,
-    ):
+
+    with caplog.at_level(logging.INTERNAL_INFO):
         result_del_inst = simulated_aux._delete_auxiliary_instance()
+
     assert result_del_inst is True
     assert "Delete auxiliary instance" in caplog.text
     mock_channel_close.assert_called()

--- a/tests/test_socketcan_to_trc.py
+++ b/tests/test_socketcan_to_trc.py
@@ -197,7 +197,7 @@ def test_on_message_received(caplog, mocker, tmp_file):
     for _ in range(10):
         logger.on_message_received(can_msg)
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         can_msg.is_error_frame = True
         logger.on_message_received(can_msg)
 

--- a/tests/test_test_case.py
+++ b/tests/test_test_case.py
@@ -132,7 +132,7 @@ def test_define_test_parameters_on_basic_tc(
     assert tc_inst.test_auxiliary_list == aux_list
 
     if setup_timeout is not None:
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INTERNAL_WARNING):
             assert (
                 "BasicTest does not support test timeouts, it will be discarded"
                 in caplog.text

--- a/tests/test_trc_handler.py
+++ b/tests/test_trc_handler.py
@@ -281,7 +281,7 @@ def test_trc_reader_can_fd_parse_cols_V2_x(mocker, trc_file_v20, cols, caplog):
 
     mocker.patch.object(TRCReaderCanFD, "_nomalize_cols", return_value=cols)
     mocker.patch.object(TRCReaderCanFD, "_parse_msg_V2_x", return_value="result")
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INTERNAL_INFO):
         result = my_reader._parse_cols_V2_x(cols)
 
     TRCReaderCanFD._nomalize_cols.assert_called_once_with(cols)

--- a/tests/test_uds_server_auxiliary.py
+++ b/tests/test_uds_server_auxiliary.py
@@ -389,7 +389,7 @@ class TestUdsServerAuxiliary:
         mocker.patch.object(UdsServerAuxiliary, "callbacks", return_value=dict())
 
         received_request = [0x01, 0x02]
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INTERNAL_WARNING):
             uds_server_aux_inst._dispatch_callback(received_request)
 
         assert "Unregistered request received" in caplog.text


### PR DESCRIPTION
**Tested and validated**

Suggestion to set the internal log levels lower than the non internal ones to that they are directly filtered out by the logging module if the configured log level is higher