### PR TITLE
fix: use pformat for config logging

### DIFF
--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -234,7 +234,7 @@ def main(
 
         # Get YAML configuration
         cfg_dict = parse_config(config_file)
-        log.debug("cfg_dict:\n%s", pprint.pprint(cfg_dict))
+        log.debug("cfg_dict:\n%s", pprint.pformat(cfg_dict))
 
         # Run tests
         with ConfigRegistry.provide_auxiliaries(cfg_dict):


### PR DESCRIPTION
As pprint was wrongly used instead of pformat (my bad), the config is now always printed out when launching a test session
Also, a step_report.html was (probably unintentionally) added in another PR