### PR TITLE
feat: replace pkg_resources with importlib.metadata for faster load time

### DIFF
--- a/src/pykiso/config_parser.py
+++ b/src/pykiso/config_parser.py
@@ -30,7 +30,11 @@ from io import TextIOBase
 from pathlib import Path
 from typing import Callable, Dict, List, TextIO, Union
 
-import pkg_resources
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
+
 import yaml
 from packaging import version
 
@@ -241,7 +245,7 @@ def check_requirements(requirements: List[dict]):
     for package, expected_version in requirements.items():
         try:
             logging.debug(f"Check YAML requirements: {package}")
-            current_version = pkg_resources.get_distribution(package).version
+            current_version = metadata.version(package)
             logging.debug(f"current_version: {current_version}")
 
             if expected_version == "any":
@@ -287,7 +291,7 @@ def check_requirements(requirements: List[dict]):
 
                 requirement_satisfied &= check
 
-        except pkg_resources.DistributionNotFound:
+        except metadata.PackageNotFoundError:
             # package not installed or misspelled
             requirement_satisfied = False
             logging.error(f"Dependency issue: {package} not found")

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -19,7 +19,12 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
-from pykiso.config_parser import YamlLoader, check_requirements, parse_config
+from pykiso.config_parser import (
+    YamlLoader,
+    check_requirements,
+    metadata,
+    parse_config,
+)
 from pykiso.exceptions import ConnectorRequiredError
 
 
@@ -557,12 +562,10 @@ def test_parse_config_folder_conflict(tmp_cfg_folder_conflict, tmp_path, caplog)
 def test_check_requirements(
     requirements, mock_installed_versions, caplog, exit_reason, mocker
 ):
-    Version = namedtuple("Version", "version")
-
     def get_version(package):
-        return Version(mock_installed_versions[package])
+        return mock_installed_versions[package]
 
-    mocker.patch("pkg_resources.get_distribution", new=get_version)
+    mocker.patch.object(metadata, "version", new=get_version)
     mock_exit = mocker.patch("sys.exit")
 
     with caplog.at_level(logging.INTERNAL_INFO):


### PR DESCRIPTION
pkg_resources was still present somewhere and takes up to 5s to be entirely loaded -> replaced with importlib.metadata or the backport importlib_metadata

Coverage check is failing because of the importlib.metadata import (has to be handled differently for py3.7), but this is already tested by the jenkins pipeline running the unit tests with py3.7