### PR TITLE
fix: enable internal file logging when junit option is provided

### DIFF
--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -157,7 +157,7 @@ def initialize_logging(
     root_logger.addHandler(stream_handler)
 
     # set the root logger's level to the internal one if any of the provided options activates internal logging
-    if verbose or log_path is not None:
+    if verbose or log_path is not None or report_type == "junit":
         root_level = get_internal_level(log_level)
     else:
         root_level = log_level

--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -104,22 +104,6 @@ class BasicTest(unittest.TestCase):
 
         self.fail(info_to_print)
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        """A class method called before tests in an individual class are
-        run.
-
-        This implementation is only mandatory to enable logging in junit
-        report. The logging configuration has to be call inside test
-        runner run, otherwise stdout is never caught.
-        """
-        options = get_logging_options()
-        if options.report_type == "junit":
-            # explicitly set the log file path to None as at this point, file logging is already configured
-            initialize_logging(
-                None, options.log_level, options.verbose, options.report_type
-            )
-
     def setUp(self) -> None:
         """Startup hook method to execute code before each test method."""
         pass

--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -115,6 +115,7 @@ class BasicTest(unittest.TestCase):
         """
         options = get_logging_options()
         if options.report_type == "junit":
+            # explicitly set the log file path to None as at this point, file logging is already configured
             initialize_logging(
                 None, options.log_level, options.verbose, options.report_type
             )

--- a/src/pykiso/test_result/xml_result.py
+++ b/src/pykiso/test_result/xml_result.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 import xmlrunner.result
 import xmlrunner.runner
 
-from .text_result import BannerTestResult
+from pykiso.logging_initializer import get_logging_options, initialize_logging
 
 
 class TestInfo(xmlrunner.result._TestInfo):
@@ -71,6 +71,17 @@ class TestInfo(xmlrunner.result._TestInfo):
         super().__init__(
             test_result, test_case, outcome, err, subTest, filename, lineno, doc
         )
+
+        # reinitialize logging inside XmlTestRunner's run
+        # otherwise stdout is never caught in the JUnit report
+        log_options = get_logging_options()
+        initialize_logging(
+            log_options.log_path,
+            log_options.log_level,
+            log_options.verbose,
+            log_options.report_type,
+        )
+
         # handle class setup error
         if isinstance(test_case, unittest.suite._ErrorHolder):
             test_case._testMethodDoc = ""
@@ -113,7 +124,6 @@ class XmlTestResult(xmlrunner.runner._XMLTestResult):
         :param properties: junit testsuite properties
         :param infoclass: class containing the test information
         """
-
         xmlrunner.runner._XMLTestResult.__init__(
             self,
             stream=stream,

--- a/tests/test_logging_initializer.py
+++ b/tests/test_logging_initializer.py
@@ -9,7 +9,6 @@
 
 import logging
 import sys
-from functools import partial
 from pathlib import Path
 
 import pytest
@@ -31,22 +30,20 @@ def test_initialize_logging(
     mocker.patch("logging.Logger.addHandler")
     mocker.patch("logging.FileHandler.__init__", return_value=None)
     mkdir_mock = mocker.patch("pathlib.Path.mkdir")
-    flush_mock = mocker.patch("logging.StreamHandler.flush", return_value=None)
 
     logger = logging_initializer.initialize_logging(path, level, verbose, report_type)
-
-    if report_type == "junit":
-        flush_mock.assert_called()
 
     if path is not None:
         mkdir_mock.assert_called()
     else:
         mkdir_mock.assert_not_called()
+
     if verbose is True:
         assert hasattr(logging, "INTERNAL_INFO")
         assert hasattr(logging, "INTERNAL_WARNING")
         assert hasattr(logging, "INTERNAL_DEBUG")
         assert logging_initializer.log_options.verbose == True
+
     assert isinstance(logger, logging.Logger)
     assert logger.isEnabledFor(expected_level)
     assert isinstance(logging_initializer.log_options.log_path, expected_path_type)

--- a/tests/test_test_case.py
+++ b/tests/test_test_case.py
@@ -211,20 +211,6 @@ def test_define_test_parameters_on_remote_tc(
     assert tc_inst.tag == tag
 
 
-def test_setUpClass(mocker):
-    mocker.patch.object(
-        test_case,
-        "get_logging_options",
-        return_value=LogOptions(None, "ERROR", "junit", False),
-    )
-    mock_init_log = mocker.patch.object(test_case, "initialize_logging")
-    test_case.BasicTest.setUpClass()
-    mock_init_log.assert_called_with(None, "ERROR", False, "junit")
-
-    test_case.RemoteTest.setUpClass()
-    mock_init_log.assert_called_with(None, "ERROR", False, "junit")
-
-
 @pytest.mark.parametrize(
     "max_try, rerun_setup, rerun_teardown, stability_test, expected_exception, expected_run_count, expected_setup_count, expected_teardown_count",
     [


### PR DESCRIPTION
When running pykiso without verbose but with the junit option provided, the internal logs were no longer displayed in the provided log file