### PR TITLE
fix: add event to avoid deadlocks on run_command calls

### DIFF
--- a/src/pykiso/interfaces/dt_auxiliary.py
+++ b/src/pykiso/interfaces/dt_auxiliary.py
@@ -181,6 +181,7 @@ class DTAuxiliaryInterface(abc.ABC):
             # if the current aux is not alive don't try to delete it again
             if not self.is_instance:
                 log.internal_info(f"Auxiliary {self.name} is already deleted")
+                self._stop_event.clear()
                 return True
 
             # stop each auxiliary's tasks

--- a/tests/test_dt_auxiliary_interface.py
+++ b/tests/test_dt_auxiliary_interface.py
@@ -277,6 +277,28 @@ def test_run_command(mocker, aux_inst):
     assert value == b"\x02"
 
 
+def test_run_command_stop_event_set(mocker, aux_inst):
+    queue_put = mocker.patch.object(aux_inst.queue_in, "put")
+    queue_get = mocker.patch.object(aux_inst.queue_out, "get", return_value=b"\x02")
+
+    aux_inst.is_instance = True
+    aux_inst._stop_event.set()
+
+    value = aux_inst.run_command(
+        cmd_message="send",
+        cmd_data=b"\x01",
+        blocking=False,
+        timeout_in_s=0,
+        timeout_result="dummy",
+    )
+
+    aux_inst._stop_event.clear()
+
+    assert queue_get.call_count == 0
+    assert queue_put.call_count == 0
+    assert value == "dummy"
+
+
 def test_run_command_timeout(mocker, aux_inst):
     queue_put = mocker.patch.object(aux_inst.queue_in, "put")
 


### PR DESCRIPTION
When a callback executed in _receive_message calls run_command while the auxiliary is being deleted, this run_command call never gets to acquire the lock (already acquired by delete_instance in the main thread) and _receive_message never terminates either.
This leads to deadlocks on delete_instance calls.

Solution is to add an event acting as a guard and preventing run_command to try and acquire the lock while the auxiliary is being deleted