### PR TITLE
fix: multiple execution if file pattern is provided

### DIFF
--- a/src/pykiso/test_coordinator/test_execution.py
+++ b/src/pykiso/test_coordinator/test_execution.py
@@ -340,6 +340,26 @@ def _is_valid_module(start_dir: str, pattern: str) -> bool:
     return all(VALID_MODULE_NAME.match(file.name) for file in test_files_found)
 
 
+def filter_test_modules_by_suite(test_modules: List[SuiteConfig]) -> List[SuiteConfig]:
+    """Filter a list of test modules by their suite directory to avoid running duplicates.
+
+    :param test_modules: List of test modules to filter.
+    :return: Filtered list of test modules with unique suite directories
+    """
+    seen_suite_dirs = {}
+    filtered_data = []
+
+    for module in test_modules:
+        suite_dir = module["suite_dir"]
+
+        # Check if the suite directory is seen for the first time
+        if suite_dir not in seen_suite_dirs:
+            seen_suite_dirs[suite_dir] = module
+            filtered_data.append(module)
+
+    return filtered_data
+
+
 def collect_test_suites(
     config_test_suite_list: List[SuiteConfig],
     test_filter_pattern: Optional[str] = None,
@@ -369,6 +389,9 @@ def collect_test_suites(
         ):
 
             valid_test_modules.append(test_suite_configuration)
+
+    if test_filter_pattern:
+        valid_test_modules = filter_test_modules_by_suite(valid_test_modules)
 
     if not valid_test_modules:
         raise TestCollectionError(

--- a/tests/test_config_registry_and_test_execution.py
+++ b/tests/test_config_registry_and_test_execution.py
@@ -31,6 +31,7 @@ from pykiso.lib.auxiliaries.proxy_auxiliary import ProxyAuxiliary
 from pykiso.lib.connectors.cc_mp_proxy import CCMpProxy
 from pykiso.lib.connectors.cc_proxy import CCProxy
 from pykiso.test_coordinator import test_execution
+from pykiso.test_coordinator.test_execution import filter_test_modules_by_suite
 from pykiso.test_setup.config_registry import ConfigRegistry
 
 
@@ -208,6 +209,25 @@ def test_test_execution_collect_error(tmp_test, capsys, mocker):
     output = capsys.readouterr()
     assert "FAIL" not in output.err
     assert "Ran 0 tests" not in output.err
+
+
+def test_filter_test_modules_by_suite():
+    test_modules = [
+        {"suite_dir": "suite1", "name": "test1"},
+        {"suite_dir": "suite2", "name": "test2"},
+        {"suite_dir": "suite1", "name": "test3"},
+        {"suite_dir": "suite3", "name": "test4"},
+    ]
+
+    filtered_modules = filter_test_modules_by_suite(test_modules)
+
+    expected_result = [
+        {"suite_dir": "suite1", "name": "test1"},
+        {"suite_dir": "suite2", "name": "test2"},
+        {"suite_dir": "suite3", "name": "test4"},
+    ]
+
+    assert filtered_modules == expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Prevent multiple execution when -p flag is given through the cli. 

Happens when multiple suite_dir are given in the config file.