### PR TITLE
fix: undecodeable bytes received from rtt segger

### DIFF
--- a/examples/record_rtt_segger.yaml
+++ b/examples/record_rtt_segger.yaml
@@ -17,6 +17,9 @@ connectors:
       verbose: True
       tx_buffer_idx: 1
       rx_buffer_idx: 1
+      # Decode strategy for undecodable bytes received by the rtt stream. Valid option are 'ignore' or 'replace'
+      # Default 'replace' to replace undecodable bytes with a suitable replacement character
+      rtt_decode_strategy: "ignore"
       # Path relative to this yaml where the RTT logs should be written to.
       # Creates a file named rtt.log
       rtt_log_path: ./

--- a/tests/test_cc_rtt_segger.py
+++ b/tests/test_cc_rtt_segger.py
@@ -143,6 +143,11 @@ def test_rtt_segger_open(mocker, mock_pylink_square_socket, search_range):
     mock_pylink_square_socket.JLink.close.assert_called_once()
 
 
+def test_rtt_segger_invalid_rtt_strategy(mocker):
+    with pytest.raises(ValueError, match=r"rtt_decode_strategy must be"):
+        cc_rtt_inst = CCRttSegger(rtt_decode_strategy="banana")
+
+
 def test_rtt_segger_close_invalid(mock_pylink_square_socket):
     cc_rtt_inst = CCRttSegger()
     cc_rtt_inst._cc_close()


### PR DESCRIPTION
Fix issue if Block Adress ist set to NULL in yaml 

Fix logging when rtt receives undecodeble bytes