### PR TITLE
fix: jlink flash

### DIFF
--- a/src/pykiso/lib/connectors/flash_jlink.py
+++ b/src/pykiso/lib/connectors/flash_jlink.py
@@ -127,7 +127,6 @@ class JLinkFlasher(Flasher):
             during flashing.
         """
         log.internal_debug("flashing device")
-        self.jlink.erase()
         self.jlink.flash_file(
             str(self.binary), addr=self.start_addr, power_on=self.power_on
         )

--- a/tests/test_flash_jlink.py
+++ b/tests/test_flash_jlink.py
@@ -77,4 +77,4 @@ def test_jlink_flasher(tmp_file, mock_jlink):
     mock_jlink.JLink.flash_file.assert_called_once()
     mock_jlink.JLink.open.assert_called_once_with(serial_no=1234)
     mock_jlink.JLink.close.assert_called_once()
-    mock_jlink.JLink.erase.assert_called_once()
+    mock_jlink.JLink.erase.assert_not_called()


### PR DESCRIPTION
Docs said call erase before flash() method but not for method flash_file (:

Seems to work again now.