### PR TITLE
fix: apply internal log level to pytest logger

### DIFF
--- a/src/pykiso/pytest_plugin/logging.py
+++ b/src/pykiso/pytest_plugin/logging.py
@@ -24,6 +24,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import pytest
+from _pytest.logging import ColoredLevelFormatter
 
 from pykiso.logging_initializer import initialize_logging
 
@@ -54,7 +55,7 @@ def pytest_sessionstart(session: Session):
 
     # run pykiso's logging initialization
     initialize_logging(
-        log_path=None,
+        log_path=pytest_logger.log_file_handler.baseFilename,
         log_level=logging.getLevelName(pytest_logger.log_cli_level),
         report_type="text",
         # display internal logs at least -vv is provided
@@ -84,8 +85,18 @@ def pytest_sessionstart(session: Session):
         pytest_logger.log_cli_handler.level != logging.NOTSET
         and stream_handler is not None
     ):
-        pytest_logger.log_cli_handler.level = stream_handler.level
         pytest_logger.log_cli_level = stream_handler.level
+        pytest_logger.log_cli_handler.level = stream_handler.level
+        if isinstance(pytest_logger.log_cli_handler.formatter, ColoredLevelFormatter):
+            pytest_logger.log_cli_handler.formatter.add_color_level(
+                logging.INTERNAL_WARNING, "yellow", "light"
+            )
+            pytest_logger.log_cli_handler.formatter.add_color_level(
+                logging.INTERNAL_INFO, "green", "light"
+            )
+            pytest_logger.log_cli_handler.formatter.add_color_level(
+                logging.INTERNAL_DEBUG, "purple", "light"
+            )
 
     if (
         pytest_logger.log_file_handler.level != logging.NOTSET

--- a/src/pykiso/pytest_plugin/logging.py
+++ b/src/pykiso/pytest_plugin/logging.py
@@ -21,6 +21,7 @@ Logging configuration
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -54,8 +55,13 @@ def pytest_sessionstart(session: Session):
         pytest_logger.log_cli_level = logging.INFO
 
     # run pykiso's logging initialization
+    if pytest_logger.log_file_handler.baseFilename == os.devnull:
+        log_file_path = None
+    else:
+        log_file_path = pytest_logger.log_file_handler.baseFilename
+
     initialize_logging(
-        log_path=pytest_logger.log_file_handler.baseFilename,
+        log_path=log_file_path,
         log_level=logging.getLevelName(pytest_logger.log_cli_level),
         report_type="text",
         # display internal logs at least -vv is provided

--- a/tests/pytest_plugin/conftest.py
+++ b/tests/pytest_plugin/conftest.py
@@ -99,9 +99,11 @@ def dummy_pytest_testmodule():
         return dedent(
             f"""
             import pytest
+            import logging
 
             @pytest.mark.tags(variant=["var1"])
             def test_mytest1(aux1):
+                logging.internal_info("Logged with INTERNAL_INFO")
                 assert aux1.is_instance == {False if add_failure else True}
 
             @pytest.mark.tags(variant="var2")

--- a/tests/pytest_plugin/test_collection.py
+++ b/tests/pytest_plugin/test_collection.py
@@ -7,10 +7,12 @@
 # SPDX-License-Identifier: EPL-2.0
 ##########################################################################
 
+import logging
 import sys
 
 import pytest
 from _pytest.pytester import Pytester
+from pytest import FixtureRequest
 
 from pykiso.test_result.text_result import ResultStream
 from pykiso.test_setup.config_registry import ConfigRegistry

--- a/tests/pytest_plugin/test_plugin.py
+++ b/tests/pytest_plugin/test_plugin.py
@@ -7,8 +7,11 @@
 # SPDX-License-Identifier: EPL-2.0
 ##########################################################################
 
+import logging
+
 import pytest
 from _pytest.pytester import Pytester
+from pytest import CaptureFixture
 
 
 @pytest.mark.slow
@@ -26,9 +29,18 @@ def test_run_pykiso_testsuite_with_tags(pytester: Pytester, dummy_pykiso_testsui
 
 
 @pytest.mark.slow
-def test_run_pytest_testsuite(pytester: Pytester, dummy_pytest_testsuite):
-    result = pytester.runpytest(dummy_pytest_testsuite)
+def test_run_pytest_testsuite(
+    pytester: Pytester, capsys: CaptureFixture, dummy_pytest_testsuite
+):
+    result = pytester.runpytest(
+        dummy_pytest_testsuite,
+        "--log-cli-level=INFO",
+        "--log-file=./tmp.log",
+        "--log-file-level=INFO",
+        "-vv",
+    )
 
+    assert "INTERNAL_INFO" in capsys.readouterr().out
     result.assert_outcomes(passed=2)
 
 

--- a/tests/pytest_plugin/test_plugin.py
+++ b/tests/pytest_plugin/test_plugin.py
@@ -30,17 +30,23 @@ def test_run_pykiso_testsuite_with_tags(pytester: Pytester, dummy_pykiso_testsui
 
 @pytest.mark.slow
 def test_run_pytest_testsuite(
-    pytester: Pytester, capsys: CaptureFixture, dummy_pytest_testsuite
+    pytester: Pytester, tmp_path, capsys: CaptureFixture, dummy_pytest_testsuite
 ):
     result = pytester.runpytest(
         dummy_pytest_testsuite,
+        "--log-level=INFO",
         "--log-cli-level=INFO",
-        "--log-file=./tmp.log",
         "--log-file-level=INFO",
+        f"--log-file={tmp_path}/test_pytest_plugin/tmp.log",
         "-vv",
     )
 
+    # verify internal logging configuration
+    with open(f"{tmp_path}/test_pytest_plugin/tmp.log") as log_file:
+        assert "INTERNAL_INFO" in log_file.read()
+
     assert "INTERNAL_INFO" in capsys.readouterr().out
+
     result.assert_outcomes(passed=2)
 
 


### PR DESCRIPTION
The refactoring of the logging mechanism broke the pytest plugin's logging configuration.

Running `pytest dummy.yaml --log-cli-level INFO -vv` now shows the INTERNAL_INFO live logs in the console