### PR TITLE
fix: two auxiliaries with the same connector and the config is None

### DIFF
--- a/src/pykiso/test_setup/config_registry.py
+++ b/src/pykiso/test_setup/config_registry.py
@@ -139,7 +139,7 @@ class ConfigRegistry:
                     auto_start = config["auxiliaries"][auxiliary]["config"][
                         "auto_start"
                     ]
-                except KeyError:
+                except (KeyError, TypeError):
                     # default value for auto_start is True
                     auto_start = True
                     break


### PR DESCRIPTION
Fix yaml with 2 auxiliaries which are using the same connector
config item of one auxiliary is set to None with the ~ character

It was raising a TypeError since the config is None:
<img width="271" alt="configissue" src="https://github.com/eclipse/kiso-testing/assets/100286656/b157cbe9-3113-4e72-89b7-51fd16215ba4">
