### PR TITLE
ci: fix codecov & release secrets

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -49,3 +49,5 @@ jobs:
       # Upload the test result
       - name: Upload test-result to codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/verification_validation.yml
+++ b/.github/workflows/verification_validation.yml
@@ -71,4 +71,4 @@ jobs:
         run: poetry install --all-extras
 
       - name: Update to Pypi
-        run: poetry publish  --no-interaction  --build  --username __token__ --password ${{ secrets.pypi_token }}
+        run: poetry publish  --no-interaction  --build  --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,35 +85,6 @@ pipeline
                 }
             }
         }
-        stage('Release')
-        {
-            when
-            {
-                buildingTag()
-            }
-            parallel
-            {
-                stage('Release package')
-                {
-                    steps
-                    {
-                        script
-                        {
-                            withCredentials([string(
-                                credentialsId: 'pypi-bot-token',
-                                variable: 'token')])
-                                {
-                                    sh "poetry publish \
-                                            --no-interaction \
-                                            --build \
-                                            --username __token__\
-                                            --password ${token}"
-                                }
-                        }
-                    }
-                }
-            } // parallel
-        } // Release
     } // stages
 
     post // Called at very end of the script to notify developer and github about the result of the build


### PR DESCRIPTION
It feels a little bit paradoxical to keep the Jenkins running in parallel but I want to see how both are performing before we switch one off.

I switched Jenkins release off so that we do not have conflicts with the github-actions.

In addition, it seems like codecov had some changes in the past and we are not able to upload anymore to it (since 2 months...). I fixed this issue too