### PR TITLE
feat: force pykiso to close if threads are blocking

### DIFF
--- a/src/pykiso/test_coordinator/test_execution.py
+++ b/src/pykiso/test_coordinator/test_execution.py
@@ -75,6 +75,7 @@ class ExitCode(enum.IntEnum):
     ONE_OR_MORE_TESTS_FAILED_AND_RAISED_UNEXPECTED_EXCEPTION = 3
     AUXILIARY_CREATION_FAILED = 4
     BAD_CLI_USAGE = 5
+    UNRESOLVED_THREADS = 6
 
 
 def create_test_suite(


### PR DESCRIPTION
Solves the issue when users spawns threads and Pykiso keeps the python process open when user threads are unresolved.