### PR TITLE
fix: fix side effect when one auxiliary get suspended

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ unittest-xml-reporting = "^3.2.0"
 click = ">=7.0.0,<9.0.0"
 tabulate = ">=0.8.9,<0.10.0"
 Jinja2 = ">=2.11.0,<4.0.0"
-MarkupSafe = "~2.0.1"                                                          # Allow support for Jinja2 between 2.11 < x < 3
+MarkupSafe = "~2.0.1" # Allow support for Jinja2 between 2.11 < x < 3
 importlib-metadata = { version = ">=4.12,<7.0", python = "<3.8" }
 pyreadline3 = { version = "^3.4.1", python = "^3.5" }
 hidapi = ">=0.12,<0.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "0.29.0"
+version = "0.29.1"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"
@@ -40,7 +40,7 @@ unittest-xml-reporting = "^3.2.0"
 click = ">=7.0.0,<9.0.0"
 tabulate = ">=0.8.9,<0.10.0"
 Jinja2 = ">=2.11.0,<4.0.0"
-MarkupSafe = "~2.0.1" # Allow support for Jinja2 between 2.11 < x < 3
+MarkupSafe = "~2.0.1"                                                          # Allow support for Jinja2 between 2.11 < x < 3
 importlib-metadata = { version = ">=4.12,<7.0", python = "<3.8" }
 pyreadline3 = { version = "^3.4.1", python = "^3.5" }
 hidapi = ">=0.12,<0.15"

--- a/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/proxy_auxiliary.py
@@ -124,7 +124,8 @@ class ProxyAuxiliary(AuxiliaryInterface):
         with self.lock:
             # on the original proxy setup, the auxiliaries are created before the proxy
             # therefore, when the first auxiliary will be stopped, the counter value will be -1
-            if value < 0:
+            # and if an auxiliary is started then stopped the counter will be 0
+            if value <= 0:
                 value = self._count_open_proxy_channels()
             last_connection_closed = value == 0 and self._open_count == 1
             first_connection_opened = value == 1 and self._open_count == 0


### PR DESCRIPTION
Fix the case when using the original proxy setup (proxy aux created and CCProxy in the yaml) , an auxiliary is started then the  `_open_connections` will be 1 then this auxiliary is stopped `_open_connections` will be 0 which will trigger the `delete_instance` that will then close the connector even if other auxiliaries still have their channel open.
It will then raise an issue when trying to send a message with an other auxiliary since it is closed when it should be opened.