### PR TITLE
fix: trace file name too long

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "1.6.0"
+version = "1.6.1"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"


### PR DESCRIPTION
Fix a case where the file name is too long to be renamed.

<img width="864" height="122" alt="image" src="https://github.com/user-attachments/assets/e6d77d36-a653-4c8d-9416-3826b7f98c65" />
