### PR TITLE
fix: ensure testsuite is a list in xray extract_test_results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "1.6.1"
+version = "1.6.2"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"

--- a/src/pykiso/tool/xray/xray.py
+++ b/src/pykiso/tool/xray/xray.py
@@ -354,10 +354,12 @@ def extract_test_results(
         # use xml to json
         for file in file_to_parse:
             with open(file) as xml_file:
-                data_dict = xmltodict.parse(xml_file.read(), attr_prefix="")
+                # Ensure 'testsuite' is always a list for consistent processing.
+                data_dict = xmltodict.parse(xml_file.read(), attr_prefix="", force_list=("testsuite",))
 
+            test_suites = data_dict["testsuites"]["testsuite"]
             xray_dict = create_result_dictionary(
-                data_dict["testsuites"]["testsuite"], jira_keys, test_execution_summary, test_execution_description
+                test_suites, jira_keys, test_execution_summary, test_execution_description
             )
             xml_results = reformat_xml_results(xray_dict, test_execution_key)
         return xml_results


### PR DESCRIPTION
When you want to upload one by one the xml file with only one testsuite in testsuites, we got this issue:
has_errors = True if int(testsuite["errors"]) > 0 else False
TypeError: string indices must be integers 

We would like that  data_dict["testsuites"]["testsuite"] is always a list.

By default xmltodict.parse has 2 behaviors. For a given level of hierarchy, 
If there is only one child (-> here testsuite), xmltodict.parse does not create a list of children (-> here testsuite)
If there are several children (-> here testsuites), xmltodict.parse  creates a list of children (-> here testsuite)
 
We can use force_list to ensure that data_dict["testsuites"]["testsuite"] is a list.
before fix:
data_dict = xmltodict.parse(xml_file.read(), attr_prefix="")
after fix:
data_dict = xmltodict.parse(xml_file.read(), attr_prefix="", force_list=("testsuite",))